### PR TITLE
ci: bump actions to v4 and add minor enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,24 @@ on:
     branches:
       - master
   pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+
+  # Allow to manually run the workflow through Github Actions.
+  workflow_dispatch:
+
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
 
 jobs:
   build:
+    name: Build & Test
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
@@ -16,25 +31,111 @@ jobs:
         include:
           - toolchain: 1.63.0
             msrv: true
+        features:
+          - default
+          - database
+          - dns
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Update Toolchain
-        run: |
-          rustup default ${{ matrix.toolchain }}
-          rustup component add --toolchain ${{ matrix.toolchain }} rustfmt
-          rustup component add --toolchain ${{ matrix.toolchain }} clippy
-          rustup update ${{ matrix.toolchain }}
-      - name: Pin dependencies
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Set Rust Profile
+        run: rustup set profile minimal
+      - name: Update Rust Toolchain
+        run: rustup update
+      - name: Pin Dependencies
         if: matrix.msrv
-        run: cargo update -p allocator-api2 --precise "0.2.9" --verbose
-      - name: Lint all targets
-        run: cargo clippy --all-targets
-      - name: Format
-        run: cargo fmt -- --check
-      - name: Build with defeault features
-        run: cargo build --verbose
-      - name: Check release build on Rust ${{ matrix.toolchain }}
-        run: cargo check --release --verbose --color always
+        run: |
+          cargo update -p allocator-api2 --precise "0.2.9" --verbose
+      - name: Build
+        run: cargo build features ${{ matrix.features }} --no-default-features
       - name: Test
-        run: cargo test --verbose
+        run: cargo test --features ${{ matrix.features }} --no-default-features
+
+  clippy:
+    name: Clippy
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        # Minumum Supported Rust Version (MSRV) is 1.63.0.
+        toolchain: [1.63.0, stable, beta, nightly]
+        include:
+          - toolchain: 1.63.0
+            msrv: true
+        features:
+          - default
+          - database
+          - dns
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Set Rust Profile
+        run: rustup set profile minimal
+      - name: Update Rust Toolchain
+        run: rustup update
+      - name: Pin Dependencies
+        if: matrix.msrv
+        run: |
+          cargo update -p allocator-api2 --precise "0.2.9" --verbose
+      - name: Clippy
+        run: cargo clippy --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
+
+  fmt:
+    name: Formatting
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        # Minumum Supported Rust Version (MSRV) is 1.63.0.
+        toolchain: [1.63.0, stable, beta, nightly]
+        include:
+          - toolchain: 1.63.0
+            msrv: true
+        features:
+          - default
+          - database
+          - dns
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Install Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - name: Update Rust Toolchain
+        run: rustup update
+      - name: Formatting
+        run: cargo fmt --all -- --config format_code_in_doc_comments=true check


### PR DESCRIPTION
- bump the github actions to actions/checkout@v4
- use dtolnay/rust-toolchain action
- split jobs into different ones for parallelism
- add concurrency to cancel previous ci run whenever a new push is done