### PR TITLE
Remove unused event `IndexedTransaction`

### DIFF
--- a/example/signet.rs
+++ b/example/signet.rs
@@ -66,7 +66,6 @@ async fn main() {
                 NodeMessage::Dialog(d) => tracing::info!("{d}"),
                 NodeMessage::Warning(e) => tracing::warn!("{e}"),
                 NodeMessage::StateChange(s) => tracing::info!("State update: {s}"),
-                NodeMessage::Transaction(t) => drop(t),
                 NodeMessage::Block(b) => drop(b),
                 NodeMessage::BlocksDisconnected(r) => {
                     let _ = r;

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -125,11 +125,11 @@ impl<H: HeaderStore> Chain<H> {
         height: u32,
     ) -> Result<Option<Header>, HeaderPersistenceError<H::Error>> {
         match self.header_chain.header_at_height(height) {
-            Some(header) => Ok(Some(header.clone())),
+            Some(header) => Ok(Some(*header)),
             None => {
                 let mut db = self.db.lock().await;
                 let header_opt = db.header_at(height).await;
-                if let Err(_) = header_opt {
+                if header_opt.is_err() {
                     self.dialog
                         .send_warning(Warning::FailedPersistance {
                             warning: format!(
@@ -138,7 +138,7 @@ impl<H: HeaderStore> Chain<H> {
                         })
                         .await;
                 }
-                header_opt.map_err(|e| HeaderPersistenceError::Database(e))
+                header_opt.map_err(HeaderPersistenceError::Database)
             }
         }
     }

--- a/src/chain/checkpoints.rs
+++ b/src/chain/checkpoints.rs
@@ -521,7 +521,7 @@ impl HeaderCheckpoint {
 
     fn headers_from_const(headers: &[(u32, &str)]) -> Vec<HeaderCheckpoint> {
         headers
-            .into_iter()
+            .iter()
             .map(|(height, hash)| {
                 HeaderCheckpoint::new(*height, BlockHash::from_str(hash).unwrap())
             })

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -7,8 +7,8 @@ use bitcoin::{block::Header, p2p::message_network::RejectReason, ScriptBuf, Txid
 #[cfg(feature = "silent-payments")]
 use crate::IndexedFilter;
 use crate::{
-    chain::checkpoints::HeaderCheckpoint, DisconnectedHeader, IndexedBlock, IndexedTransaction,
-    TrustedPeer, TxBroadcast,
+    chain::checkpoints::HeaderCheckpoint, DisconnectedHeader, IndexedBlock, TrustedPeer,
+    TxBroadcast,
 };
 
 use super::{error::FetchHeaderError, node::NodeState};
@@ -24,8 +24,6 @@ pub enum NodeMessage {
     StateChange(NodeState),
     /// The node is connected to all required peers.
     ConnectionsMet,
-    /// A relevant transaction based on the user provided scripts.
-    Transaction(IndexedTransaction),
     /// A relevant [`Block`](crate) based on the user provided scripts.
     /// Note that the block may not contain any transactions contained in the script set.
     /// This is due to block filters having a non-zero false-positive rate when compressing data.

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -320,7 +320,8 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                             ClientMessage::GetHeader(request) => {
                                 let mut chain = self.chain.lock().await;
                                 let header_opt = chain.fetch_header(request.height).await;
-                                if let Err(_) = request.oneshot.send(header_opt.map_err(|e| FetchHeaderError::DatabaseOptFailed { error: e.to_string() })) {
+                                let send_result = request.oneshot.send(header_opt.map_err(|e| FetchHeaderError::DatabaseOptFailed { error: e.to_string() }));
+                                if send_result.is_err() {
                                     self.dialog.send_warning(Warning::ChannelDropped).await
                                 };
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,8 @@ pub use tokio::sync::broadcast::Receiver;
 
 /// A Bitcoin [`Transaction`] with additional context.
 #[derive(Debug, Clone)]
-pub struct IndexedTransaction {
+#[allow(dead_code)]
+pub(crate) struct IndexedTransaction {
     /// The Bitcoin transaction.
     pub transaction: Transaction,
     /// The height of the block in the chain that includes this transaction.


### PR DESCRIPTION
Misleading as this event is not currently issued. Should potentially be added back in the future if there is a use for it.