### PR TITLE
Separate log and event receivers

### DIFF
--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -5,348 +5,280 @@ use bitcoin::BlockHash;
 use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
 use std::time::Duration;
-use tokio::sync::broadcast;
-pub use tokio::sync::broadcast::Receiver;
+use tokio::sync::mpsc;
+pub use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
+pub use tokio::sync::mpsc::UnboundedReceiver;
 
-use crate::{IndexedBlock, TrustedPeer, TxBroadcast};
+use crate::{Event, Log, TrustedPeer, TxBroadcast};
 
 #[cfg(feature = "filter-control")]
-use super::{error::FetchBlockError, messages::BlockRequest, BlockReceiver};
+use super::{error::FetchBlockError, messages::BlockRequest, BlockReceiver, IndexedBlock};
 use super::{
     error::{ClientError, FetchHeaderError},
-    messages::{ClientMessage, HeaderRequest, NodeMessage, SyncUpdate},
+    messages::{ClientMessage, HeaderRequest},
 };
 
 /// A [`Client`] allows for communication with a running node.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Client {
-    nrx: broadcast::Sender<NodeMessage>,
-    ntx: Sender<ClientMessage>,
+    /// Send events to a node, such as broadcasting a transaction.
+    pub sender: EventSender,
+    /// Receive log messages from a node.
+    pub log_rx: mpsc::Receiver<Log>,
+    /// Receive [`Event`] from a node to act on.
+    pub event_rx: mpsc::UnboundedReceiver<Event>,
 }
 
 impl Client {
-    pub(crate) fn new(nrx: broadcast::Sender<NodeMessage>, ntx: Sender<ClientMessage>) -> Self {
-        Self { nrx, ntx }
-    }
-
-    /// For a majority of cases, some parts of your program will respond to node events, and other parts of the program
-    /// will send events to the node. This method returns a [`ClientSender`] to issue commands to the node, and a
-    /// [`Receiver`] to continually respond to events issued from the node.
-    pub fn split(&self) -> (ClientSender, Receiver<NodeMessage>) {
-        (self.sender(), self.receiver())
-    }
-
-    /// Return a [`ClientSender`], which may send commands to a running node.
-    pub fn sender(&self) -> ClientSender {
-        ClientSender::new(self.ntx.clone())
-    }
-
-    /// Return a [`Receiver`] to listen for incoming node events.
-    /// You may call this function as many times as required, however please note
-    /// there are memory and performance implications when calling this method. Namely, a clone of the object,
-    /// potentially a large data structure like a [`crate::Block`], is held in memory for _every_ receiver until _all_
-    /// receivers have gotten the message.
-    /// You should only call this twice if two separate portions of your application need to process
-    /// data differently. For example, a Lightning Network node implementation.
-    pub fn receiver(&self) -> Receiver<NodeMessage> {
-        self.nrx.subscribe()
-    }
-
-    /// Collect the blocks received from the node into an in-memory cache,
-    /// returning once the node is synced to its peers.
-    /// Only recommended for machines that can tolerate such a memory allocation,
-    /// like a server or desktop computer. Internally, this method also creates a new receiver,
-    /// which has more performance implications.
-    /// For devices like smart phones, it is advisable to
-    /// respond to each block in an event loop. See [`Client::split`] or [`Client::receiver`].
-    pub async fn collect_relevant_blocks(&mut self) -> Vec<IndexedBlock> {
-        let mut rec = self.nrx.subscribe();
-        let mut blocks = Vec::new();
-        loop {
-            while let Ok(message) = rec.recv().await {
-                match message {
-                    NodeMessage::Block(block) => blocks.push(block),
-                    NodeMessage::Synced(_) => {
-                        drop(rec);
-                        return blocks;
-                    }
-                    _ => (),
-                }
-            }
-        }
-    }
-
-    /// Wait until the client's headers and filters are fully synced to connected peers, dropping any block and transaction messages.
-    /// For new wallets, no blocks should be interesting yet.
-    pub async fn wait_until_synced(&mut self) -> SyncUpdate {
-        let mut rec = self.nrx.subscribe();
-        loop {
-            while let Ok(message) = rec.recv().await {
-                if let NodeMessage::Synced(update) = message {
-                    return update;
-                }
-            }
+    pub(crate) fn new(
+        log_rx: mpsc::Receiver<Log>,
+        event_rx: mpsc::UnboundedReceiver<Event>,
+        ntx: Sender<ClientMessage>,
+    ) -> Self {
+        Self {
+            sender: EventSender::new(ntx),
+            log_rx,
+            event_rx,
         }
     }
 }
 
 /// Send messages to a node that is running so the node may complete a task.
 #[derive(Debug, Clone)]
-pub struct ClientSender {
+pub struct EventSender {
     ntx: Sender<ClientMessage>,
 }
 
-impl ClientSender {
+impl EventSender {
     fn new(ntx: Sender<ClientMessage>) -> Self {
         Self { ntx }
     }
 }
 
-macro_rules! impl_core_client {
-    ($client:ident) => {
-        impl $client {
-            /// Tell the node to shut down.
-            ///
-            /// # Errors
-            ///
-            /// If the node has already stopped running.
-            pub async fn shutdown(&self) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::Shutdown)
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+impl EventSender {
+    /// Tell the node to shut down.
+    ///
+    /// # Errors
+    ///
+    /// If the node has already stopped running.
+    pub async fn shutdown(&self) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::Shutdown)
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Tell the node to shut down from a synchronus context.
-            ///
-            /// # Errors
-            ///
-            /// If the node has already stopped running.
-            pub fn shutdown_blocking(&self) -> Result<(), ClientError> {
-                self.ntx
-                    .blocking_send(ClientMessage::Shutdown)
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Tell the node to shut down from a synchronus context.
+    ///
+    /// # Errors
+    ///
+    /// If the node has already stopped running.
+    pub fn shutdown_blocking(&self) -> Result<(), ClientError> {
+        self.ntx
+            .blocking_send(ClientMessage::Shutdown)
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Broadcast a new transaction to the network.
-            ///
-            /// # Note
-            ///
-            /// When broadcasting a one-parent one-child (TRUC) package,
-            /// broadcast the child first, followed by the parent.
-            ///
-            /// Package relay is under-development at the time of writing.
-            ///
-            /// For more information, see BIP-431 and BIP-331.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn broadcast_tx(&self, tx: TxBroadcast) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::Broadcast(tx))
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Broadcast a new transaction to the network.
+    ///
+    /// # Note
+    ///
+    /// When broadcasting a one-parent one-child (TRUC) package,
+    /// broadcast the child first, followed by the parent.
+    ///
+    /// Package relay is under-development at the time of writing.
+    ///
+    /// For more information, see BIP-431 and BIP-331.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn broadcast_tx(&self, tx: TxBroadcast) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::Broadcast(tx))
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Broadcast a new transaction to the network to a random peer.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn broadcast_random(&self, tx: Transaction) -> Result<(), ClientError> {
-                let tx_broadcast = TxBroadcast::random_broadcast(tx);
-                self.ntx
-                    .send(ClientMessage::Broadcast(tx_broadcast))
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Broadcast a new transaction to the network to a random peer.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn broadcast_random(&self, tx: Transaction) -> Result<(), ClientError> {
+        let tx_broadcast = TxBroadcast::random_broadcast(tx);
+        self.ntx
+            .send(ClientMessage::Broadcast(tx_broadcast))
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Broadcast a new transaction to the network from a synchronus context.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub fn broadcast_tx_blocking(&self, tx: TxBroadcast) -> Result<(), ClientError> {
-                self.ntx
-                    .blocking_send(ClientMessage::Broadcast(tx))
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Broadcast a new transaction to the network from a synchronus context.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub fn broadcast_tx_blocking(&self, tx: TxBroadcast) -> Result<(), ClientError> {
+        self.ntx
+            .blocking_send(ClientMessage::Broadcast(tx))
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Add more Bitcoin [`ScriptBuf`] to watch for. Does not rescan the filters.
-            /// If the script was already present in the node's collection, no change will occur.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            #[cfg(not(feature = "filter-control"))]
-            pub async fn add_script(
-                &self,
-                script: impl Into<ScriptBuf>,
-            ) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::AddScript(script.into()))
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Add more Bitcoin [`ScriptBuf`] to watch for. Does not rescan the filters.
+    /// If the script was already present in the node's collection, no change will occur.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    #[cfg(not(feature = "filter-control"))]
+    pub async fn add_script(&self, script: impl Into<ScriptBuf>) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::AddScript(script.into()))
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Add more Bitcoin [`ScriptBuf`] to watch for from a synchronus context. Does not rescan the filters.
-            /// If the script was already present in the node's collection, no change will occur.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            #[cfg(not(feature = "filter-control"))]
-            pub fn add_script_blocking(
-                &self,
-                script: impl Into<ScriptBuf>,
-            ) -> Result<(), ClientError> {
-                self.ntx
-                    .blocking_send(ClientMessage::AddScript(script.into()))
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Add more Bitcoin [`ScriptBuf`] to watch for from a synchronus context. Does not rescan the filters.
+    /// If the script was already present in the node's collection, no change will occur.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    #[cfg(not(feature = "filter-control"))]
+    pub fn add_script_blocking(&self, script: impl Into<ScriptBuf>) -> Result<(), ClientError> {
+        self.ntx
+            .blocking_send(ClientMessage::AddScript(script.into()))
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Get a header at the specified height, if it exists.
-            ///
-            /// # Note
-            ///
-            /// The height of the chain is the canonical index of the header in the chain.
-            /// For example, the genesis block is at a height of zero.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn get_header(&self, height: u32) -> Result<Header, FetchHeaderError> {
-                let (tx, rx) = tokio::sync::oneshot::channel::<Result<Header, FetchHeaderError>>();
-                let message = HeaderRequest::new(tx, height);
-                self.ntx
-                    .send(ClientMessage::GetHeader(message))
-                    .await
-                    .map_err(|_| FetchHeaderError::SendError)?;
-                rx.await.map_err(|_| FetchHeaderError::RecvError)?
-            }
+    /// Get a header at the specified height, if it exists.
+    ///
+    /// # Note
+    ///
+    /// The height of the chain is the canonical index of the header in the chain.
+    /// For example, the genesis block is at a height of zero.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn get_header(&self, height: u32) -> Result<Header, FetchHeaderError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Header, FetchHeaderError>>();
+        let message = HeaderRequest::new(tx, height);
+        self.ntx
+            .send(ClientMessage::GetHeader(message))
+            .await
+            .map_err(|_| FetchHeaderError::SendError)?;
+        rx.await.map_err(|_| FetchHeaderError::RecvError)?
+    }
 
-            /// Get a header at the specified height in a synchronus context, if it exists.
-            ///
-            /// # Note
-            ///
-            /// The height of the chain is the canonical index of the header in the chain.
-            /// For example, the genesis block is at a height of zero.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub fn get_header_blocking(&self, height: u32) -> Result<Header, FetchHeaderError> {
-                let (tx, rx) = tokio::sync::oneshot::channel::<Result<Header, FetchHeaderError>>();
-                let message = HeaderRequest::new(tx, height);
-                self.ntx
-                    .blocking_send(ClientMessage::GetHeader(message))
-                    .map_err(|_| FetchHeaderError::SendError)?;
-                rx.blocking_recv()
-                    .map_err(|_| FetchHeaderError::RecvError)?
-            }
+    /// Get a header at the specified height in a synchronus context, if it exists.
+    ///
+    /// # Note
+    ///
+    /// The height of the chain is the canonical index of the header in the chain.
+    /// For example, the genesis block is at a height of zero.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub fn get_header_blocking(&self, height: u32) -> Result<Header, FetchHeaderError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<Header, FetchHeaderError>>();
+        let message = HeaderRequest::new(tx, height);
+        self.ntx
+            .blocking_send(ClientMessage::GetHeader(message))
+            .map_err(|_| FetchHeaderError::SendError)?;
+        rx.blocking_recv()
+            .map_err(|_| FetchHeaderError::RecvError)?
+    }
 
-            /// Request a block be fetched. Note that this method will request a block
-            /// from a connected peer's inventory, and may take an indefinite amount of
-            /// time, until a peer responds.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            #[cfg(feature = "filter-control")]
-            pub async fn get_block(
-                &self,
-                block_hash: BlockHash,
-            ) -> Result<IndexedBlock, FetchBlockError> {
-                let (tx, rx) =
-                    tokio::sync::oneshot::channel::<Result<IndexedBlock, FetchBlockError>>();
-                let message = BlockRequest::new(tx, block_hash);
-                self.ntx
-                    .send(ClientMessage::GetBlock(message))
-                    .await
-                    .map_err(|_| FetchBlockError::SendError)?;
-                rx.await.map_err(|_| FetchBlockError::RecvError)?
-            }
+    /// Request a block be fetched. Note that this method will request a block
+    /// from a connected peer's inventory, and may take an indefinite amount of
+    /// time, until a peer responds.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    #[cfg(feature = "filter-control")]
+    pub async fn get_block(&self, block_hash: BlockHash) -> Result<IndexedBlock, FetchBlockError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<IndexedBlock, FetchBlockError>>();
+        let message = BlockRequest::new(tx, block_hash);
+        self.ntx
+            .send(ClientMessage::GetBlock(message))
+            .await
+            .map_err(|_| FetchBlockError::SendError)?;
+        rx.await.map_err(|_| FetchBlockError::RecvError)?
+    }
 
-            /// Request a block be fetched and receive a [`tokio::sync::oneshot::Receiver`]
-            /// to await the resulting block.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            #[cfg(feature = "filter-control")]
-            pub async fn request_block(
-                &self,
-                block_hash: BlockHash,
-            ) -> Result<BlockReceiver, FetchBlockError> {
-                let (tx, rx) =
-                    tokio::sync::oneshot::channel::<Result<IndexedBlock, FetchBlockError>>();
-                let message = BlockRequest::new(tx, block_hash);
-                self.ntx
-                    .send(ClientMessage::GetBlock(message))
-                    .await
-                    .map_err(|_| FetchBlockError::SendError)?;
-                Ok(rx)
-            }
+    /// Request a block be fetched and receive a [`tokio::sync::oneshot::Receiver`]
+    /// to await the resulting block.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    #[cfg(feature = "filter-control")]
+    pub async fn request_block(
+        &self,
+        block_hash: BlockHash,
+    ) -> Result<BlockReceiver, FetchBlockError> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<IndexedBlock, FetchBlockError>>();
+        let message = BlockRequest::new(tx, block_hash);
+        self.ntx
+            .send(ClientMessage::GetBlock(message))
+            .await
+            .map_err(|_| FetchBlockError::SendError)?;
+        Ok(rx)
+    }
 
-            /// Starting at the configured anchor checkpoint, look for block inclusions with newly added scripts.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn rescan(&self) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::Rescan)
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Starting at the configured anchor checkpoint, look for block inclusions with newly added scripts.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn rescan(&self) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::Rescan)
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Set a new connection timeout for peers to respond to messages.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn set_response_timeout(
-                &self,
-                duration: Duration,
-            ) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::SetDuration(duration))
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Set a new connection timeout for peers to respond to messages.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn set_response_timeout(&self, duration: Duration) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::SetDuration(duration))
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Add another known peer to connect to.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn add_peer(&self, peer: impl Into<TrustedPeer>) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::AddPeer(peer.into()))
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
+    /// Add another known peer to connect to.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn add_peer(&self, peer: impl Into<TrustedPeer>) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::AddPeer(peer.into()))
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 
-            /// Explicitly start the block filter syncing process. Note that the node will automatically download and check
-            /// filters unless the policy is to explicitly halt.
-            ///
-            /// # Errors
-            ///
-            /// If the node has stopped running.
-            pub async fn continue_download(&self) -> Result<(), ClientError> {
-                self.ntx
-                    .send(ClientMessage::ContinueDownload)
-                    .await
-                    .map_err(|_| ClientError::SendError)
-            }
-        }
-    };
+    /// Explicitly start the block filter syncing process. Note that the node will automatically download and check
+    /// filters unless the policy is to explicitly halt.
+    ///
+    /// # Errors
+    ///
+    /// If the node has stopped running.
+    pub async fn continue_download(&self) -> Result<(), ClientError> {
+        self.ntx
+            .send(ClientMessage::ContinueDownload)
+            .await
+            .map_err(|_| ClientError::SendError)
+    }
 }
-
-impl_core_client!(Client);
-impl_core_client!(ClientSender);
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for ClientError {
     fn from(_: tokio::sync::mpsc::error::SendError<T>) -> Self {
@@ -364,22 +296,30 @@ mod tests {
     #[tokio::test]
     async fn test_client_works() {
         let transaction: Transaction = deserialize(&hex::decode("0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000").unwrap()).unwrap();
-        let (ntx, _) = broadcast::channel::<NodeMessage>(32);
+        let (log_tx, log_rx) = tokio::sync::mpsc::channel::<Log>(1);
+        let (_, event_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
-        let client = Client::new(ntx.clone(), ctx);
-        let mut recv = client.receiver();
-        let send_res = ntx.send(NodeMessage::Dialog("An important message".into()));
+        let Client {
+            sender,
+            mut log_rx,
+            event_rx: _,
+        } = Client::new(log_rx, event_rx, ctx);
+        let send_res = log_tx
+            .send(Log::Dialog("An important message".into()))
+            .await;
         assert!(send_res.is_ok());
-        let message = recv.recv().await;
-        assert!(message.is_ok());
+        let message = log_rx.recv().await;
+        assert!(message.is_some());
         tokio::task::spawn(async move {
-            ntx.send(NodeMessage::Dialog("Another important message".into()))
+            log_tx
+                .send(Log::Dialog("Another important message".into()))
+                .await
         });
         assert!(send_res.is_ok());
-        let message = recv.recv().await;
-        assert!(message.is_ok());
-        drop(recv);
-        let broadcast = client
+        let message = log_rx.recv().await;
+        assert!(message.is_some());
+        drop(log_rx);
+        let broadcast = sender
             .broadcast_tx(TxBroadcast::new(
                 transaction.clone(),
                 crate::TxBroadcastPolicy::AllPeers,
@@ -387,7 +327,7 @@ mod tests {
             .await;
         assert!(broadcast.is_ok());
         drop(crx);
-        let broadcast = client.shutdown().await;
+        let broadcast = sender.shutdown().await;
         assert!(broadcast.is_err());
     }
 }

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -1,19 +1,20 @@
-use tokio::sync::broadcast::Sender;
+use tokio::sync::mpsc::{Sender, UnboundedSender};
 
-use super::messages::{NodeMessage, Progress, Warning};
+use super::messages::{Event, Log, Progress, Warning};
 
 #[derive(Debug, Clone)]
 pub(crate) struct Dialog {
-    ntx: Sender<NodeMessage>,
+    log_tx: Sender<Log>,
+    event_tx: UnboundedSender<Event>,
 }
 
 impl Dialog {
-    pub(crate) fn new(ntx: Sender<NodeMessage>) -> Self {
-        Self { ntx }
+    pub(crate) fn new(log_tx: Sender<Log>, event_tx: UnboundedSender<Event>) -> Self {
+        Self { log_tx, event_tx }
     }
 
     pub(crate) async fn send_dialog(&self, dialog: impl Into<String>) {
-        let _ = self.ntx.send(NodeMessage::Dialog(dialog.into()));
+        let _ = self.log_tx.send(Log::Dialog(dialog.into())).await;
     }
 
     pub(crate) async fn chain_update(
@@ -23,23 +24,30 @@ impl Dialog {
         num_filters: u32,
         best_height: u32,
     ) {
-        let _ = self.ntx.send(NodeMessage::Progress(Progress::new(
-            num_cf_headers,
-            num_filters,
-            best_height,
-        )));
+        let _ = self
+            .log_tx
+            .send(Log::Progress(Progress::new(
+                num_cf_headers,
+                num_filters,
+                best_height,
+            )))
+            .await;
         let message = format!(
             "Headers ({}/{}) Compact Filter Headers ({}/{}) Filters ({}/{})",
             num_headers, best_height, num_cf_headers, best_height, num_filters, best_height
         );
-        let _ = self.ntx.send(NodeMessage::Dialog(message));
+        let _ = self.log_tx.send(Log::Dialog(message)).await;
     }
 
     pub(crate) async fn send_warning(&self, warning: Warning) {
-        let _ = self.ntx.send(NodeMessage::Warning(warning));
+        let _ = self.log_tx.send(Log::Warning(warning)).await;
     }
 
-    pub(crate) async fn send_data(&self, message: NodeMessage) {
-        let _ = self.ntx.send(message);
+    pub(crate) async fn send_info(&self, info: Log) {
+        let _ = self.log_tx.send(info).await;
+    }
+
+    pub(crate) async fn send_event(&self, message: Event) {
+        let _ = self.event_tx.send(message);
     }
 }

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -16,9 +16,9 @@ use super::{
     node::NodeState,
 };
 
-/// Messages receivable by a running node.
+/// Informational messages emitted by a node
 #[derive(Debug, Clone)]
-pub enum NodeMessage {
+pub enum Log {
     /// Human readable dialog of what the node is currently doing.
     Dialog(String),
     /// A warning that may effect the function of the node.
@@ -27,20 +27,25 @@ pub enum NodeMessage {
     StateChange(NodeState),
     /// The node is connected to all required peers.
     ConnectionsMet,
+    /// The progress of the node during the block filter download process.
+    Progress(Progress),
+    /// A transaction was sent to one or more connected peers.
+    /// This does not guarentee the transaction will be relayed or accepted by the peers,
+    /// only that the message was sent over the wire.
+    TxSent(Txid),
+}
+
+/// Data and structures useful for a consumer, such as a wallet.
+#[derive(Debug, Clone)]
+pub enum Event {
     /// A relevant [`Block`](crate) based on the user provided scripts.
     /// Note that the block may not contain any transactions contained in the script set.
     /// This is due to block filters having a non-zero false-positive rate when compressing data.
     Block(IndexedBlock),
     /// The node is fully synced, having scanned the requested range.
     Synced(SyncUpdate),
-    /// The progress of the node during the block filter download process.
-    Progress(Progress),
     /// Blocks were reorganized out of the chain.
     BlocksDisconnected(Vec<DisconnectedHeader>),
-    /// A transaction was sent to one or more connected peers.
-    /// This does not guarentee the transaction will be relayed or accepted by the peers,
-    /// only that the message was sent over the wire.
-    TxSent(Txid),
     /// A problem occured sending a transaction. Either the remote node disconnected or the transaction was rejected.
     TxBroadcastFailure(FailurePayload),
     /// A connection has a minimum transaction fee requirement to enter its mempool. For proper transaction propagation,

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -21,7 +21,7 @@ use crate::{
         PeerTimeoutConfig,
     },
     network::outbound_messages::V1OutboundMessage,
-    NodeMessage,
+    Event,
 };
 
 use super::{
@@ -297,7 +297,7 @@ impl Peer {
             }
             PeerMessage::Pong(_) => Ok(()),
             PeerMessage::FeeFilter(fee) => {
-                self.dialog.send_data(NodeMessage::FeeFilter(fee)).await;
+                self.dialog.send_event(Event::FeeFilter(fee)).await;
                 Ok(())
             }
             PeerMessage::Reject(payload) => {


### PR DESCRIPTION
A client can miss an event if the channel receiver is bounded. Logs are limited to a buffer of 32, but events are now unbounded.