### PR TITLE
Allow for a `RangeBounds` of heights to load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,15 +1462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "hostname-validator"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4200,14 +4191,13 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "4.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
 dependencies = [
  "either",
- "home",
- "once_cell",
- "rustix",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]
@@ -4232,7 +4222,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ hex = { version = "0.4.0" }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tempfile = "3"
-tokio = { version = "1", default-features = false, features = [
+tokio = { version = "1.37", default-features = false, features = [
     "full",
 ] } # add feature "tracing" to use the console
 # Enable the tokio-console task and poll observations

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -279,7 +279,7 @@ impl<H: HeaderStore> Chain<H> {
             .db
             .lock()
             .await
-            .load_after(self.height())
+            .load(self.height() + 1..)
             .await
             .map_err(HeaderPersistenceError::Database)?;
         if let Some(first) = loaded_headers.values().next() {


### PR DESCRIPTION
A more robust header DB trait will allow for loading a range of headers from the client.