### PR TITLE
Fetch a range of headers from client

### DIFF
--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -74,6 +74,10 @@ impl EventSender {
     /// # Errors
     ///
     /// If the node has already stopped running.
+    ///
+    /// # Panics
+    ///
+    /// When called within an asynchronus context (e.g `tokio::main`).
     pub fn shutdown_blocking(&self) -> Result<(), ClientError> {
         self.ntx
             .blocking_send(ClientMessage::Shutdown)
@@ -119,6 +123,10 @@ impl EventSender {
     /// # Errors
     ///
     /// If the node has stopped running.
+    ///
+    /// # Panics
+    ///
+    /// When called within an asynchronus context (e.g `tokio::main`).
     pub fn broadcast_tx_blocking(&self, tx: TxBroadcast) -> Result<(), ClientError> {
         self.ntx
             .blocking_send(ClientMessage::Broadcast(tx))
@@ -145,6 +153,10 @@ impl EventSender {
     /// # Errors
     ///
     /// If the node has stopped running.
+    ///
+    /// # Panics
+    ///
+    /// When called within an asynchronus context (e.g `tokio::main`).
     #[cfg(not(feature = "filter-control"))]
     pub fn add_script_blocking(&self, script: impl Into<ScriptBuf>) -> Result<(), ClientError> {
         self.ntx
@@ -182,6 +194,10 @@ impl EventSender {
     /// # Errors
     ///
     /// If the node has stopped running.
+    ///
+    /// # Panics
+    ///
+    /// When called within an asynchronus context (e.g `tokio::main`).
     pub fn get_header_blocking(&self, height: u32) -> Result<Header, FetchHeaderError> {
         let (tx, rx) = tokio::sync::oneshot::channel::<Result<Header, FetchHeaderError>>();
         let message = HeaderRequest::new(tx, height);

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::{collections::BTreeMap, ops::Range, time::Duration};
 
 #[cfg(feature = "filter-control")]
 use bitcoin::BlockHash;
@@ -158,6 +158,8 @@ pub(crate) enum ClientMessage {
     AddPeer(TrustedPeer),
     /// Request a header from a specified height.
     GetHeader(HeaderRequest),
+    /// Request a range of headers.
+    GetHeaderBatch(BatchHeaderRequest),
 }
 
 type HeaderSender = tokio::sync::oneshot::Sender<Result<Header, FetchHeaderError>>;
@@ -171,6 +173,21 @@ pub(crate) struct HeaderRequest {
 impl HeaderRequest {
     pub(crate) fn new(oneshot: HeaderSender, height: u32) -> Self {
         Self { oneshot, height }
+    }
+}
+
+type BatchHeaderSender =
+    tokio::sync::oneshot::Sender<Result<BTreeMap<u32, Header>, FetchHeaderError>>;
+
+#[derive(Debug)]
+pub(crate) struct BatchHeaderRequest {
+    pub(crate) oneshot: BatchHeaderSender,
+    pub(crate) range: Range<u32>,
+}
+
+impl BatchHeaderRequest {
+    pub(crate) fn new(oneshot: BatchHeaderSender, range: Range<u32>) -> Self {
+        Self { oneshot, range }
     }
 }
 

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -324,6 +324,14 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                 if send_result.is_err() {
                                     self.dialog.send_warning(Warning::ChannelDropped).await
                                 };
+                            },
+                            ClientMessage::GetHeaderBatch(request) => {
+                                let chain = self.chain.lock().await;
+                                let range_opt = chain.fetch_header_range(request.range).await.map_err(|e| FetchHeaderError::DatabaseOptFailed { error: e.to_string() });
+                                let send_result = request.oneshot.send(range_opt);
+                                if send_result.is_err() {
+                                    self.dialog.send_warning(Warning::ChannelDropped).await
+                                };
                             }
                         }
                     }

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -274,6 +274,8 @@ async fn test_long_chain() {
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
+    let batch = sender.get_header_range(10_000..10_002).await.unwrap();
+    assert!(batch.is_empty());
     sender.shutdown().await.unwrap();
     rpc.stop().unwrap();
 }
@@ -304,6 +306,8 @@ async fn test_sql_reorg() {
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
+    let batch = sender.get_header_range(0..10).await.unwrap();
+    assert!(!batch.is_empty());
     sender.shutdown().await.unwrap();
     // Reorganize the blocks
     let old_best = best;


### PR DESCRIPTION
Especially for consumers that have strict chain ordering requirements, like LDK, batching requests for headers should greatly speed up sync times.