### PR TITLE
Export `tokio` and remove module exports for `mpsc` in client

### DIFF
--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -6,9 +6,7 @@ use bitcoin::Transaction;
 use bitcoin::{block::Header, FeeRate};
 use std::{collections::BTreeMap, ops::Range, time::Duration};
 use tokio::sync::mpsc;
-pub use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
-pub use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::{Event, Log, TrustedPeer, TxBroadcast};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,6 +138,8 @@ pub use bitcoin::{
     Address, Block, BlockHash, FeeRate, Network, ScriptBuf, Transaction, Txid,
 };
 
+pub extern crate tokio;
+
 /// A Bitcoin [`Transaction`] with additional context.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -11,12 +11,10 @@ use corepc_node::serde_json;
 use corepc_node::{anyhow, exe_path};
 use kyoto::{
     chain::checkpoints::HeaderCheckpoint,
-    core::{
-        client::{Client, Receiver},
-        node::Node,
-    },
+    core::{client::Client, node::Node},
     BlockHash, Event, Log, NodeState, ServiceFlags, SqliteHeaderDb, SqlitePeerDb, TrustedPeer,
 };
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 // Start the bitcoin daemon either through an environment variable or by download


### PR DESCRIPTION
It seems to be the best practice to re export crates that users must import anyway, and `tokio` is particularly large. Users may make use of types I had not considered without explicitly importing `tokio`. 

ref: https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/src/lib.rs#L66