### PR TITLE
Rename `EventSender` to `Requester`

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -52,7 +52,7 @@ async fn main() {
     tokio::task::spawn(async move { node.run().await });
 
     let Client {
-        sender,
+        requester,
         mut log_rx,
         mut event_rx,
     } = client;
@@ -78,7 +78,7 @@ async fn main() {
                             if filter.contains_any(&addresses) {
                                 let hash = *filter.block_hash();
                                 tracing::info!("Found script at {}!", hash);
-                                let indexed_block = sender.get_block(hash).await.unwrap();
+                                let indexed_block = requester.get_block(hash).await.unwrap();
                                 let coinbase = indexed_block.block.txdata.first().unwrap().compute_txid();
                                 tracing::info!("Coinbase transaction ID: {}", coinbase);
                                 break;
@@ -91,6 +91,6 @@ async fn main() {
             }
         }
     }
-    let _ = sender.shutdown().await;
+    let _ = requester.shutdown().await;
     tracing::info!("Shutting down");
 }

--- a/example/rescan.rs
+++ b/example/rescan.rs
@@ -43,7 +43,7 @@ async fn main() {
     tracing::info!("Running the node and waiting for a sync message. Please wait a minute!");
     // Split the client into components that send messages and listen to messages
     let Client {
-        sender,
+        requester,
         mut log_rx,
         mut event_rx,
     } = client;
@@ -74,9 +74,9 @@ async fn main() {
             .unwrap()
             .require_network(NETWORK)
             .unwrap();
-    sender.add_script(new_script).await.unwrap();
+    requester.add_script(new_script).await.unwrap();
     // // Tell the node to look for these new scripts
-    sender.rescan().await.unwrap();
+    requester.rescan().await.unwrap();
     tracing::info!("Starting rescan");
     loop {
         tokio::select! {
@@ -98,6 +98,6 @@ async fn main() {
             }
         }
     }
-    let _ = sender.shutdown().await;
+    let _ = requester.shutdown().await;
     tracing::info!("Shutting down");
 }

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -55,7 +55,7 @@ async fn main() {
     // With this construction, different parts of the program can take ownership of
     // specific tasks.
     let Client {
-        sender,
+        requester,
         mut log_rx,
         mut event_rx,
     } = client;
@@ -69,7 +69,7 @@ async fn main() {
                             tracing::info!("Synced chain up to block {}",update.tip().height);
                             tracing::info!("Chain tip: {}",update.tip().hash);
                             // Request information from the node
-                            let fee = sender.broadcast_min_feerate().await.unwrap();
+                            let fee = requester.broadcast_min_feerate().await.unwrap();
                             tracing::info!("Minimum transaction broadcast fee rate: {}", fee);
                             break;
                         },
@@ -97,6 +97,6 @@ async fn main() {
             }
         }
     }
-    let _ = sender.shutdown().await;
+    let _ = requester.shutdown().await;
     tracing::info!("Shutting down");
 }

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -50,7 +50,7 @@ async fn main() {
     // With this construction, different parts of the program can take ownership of
     // specific tasks.
     let Client {
-        sender,
+        requester,
         mut log_rx,
         mut event_rx,
     } = client;
@@ -89,6 +89,6 @@ async fn main() {
             }
         }
     }
-    let _ = sender.shutdown().await;
+    let _ = requester.shutdown().await;
     tracing::info!("Shutting down");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!     // Run the node and wait for the sync message;
 //!     tokio::task::spawn(async move { node.run().await });
 //!     // Split the client into components that send messages and listen to messages
-//!     let Client { sender, mut log_rx, mut event_rx } = client;
+//!     let Client { requester, mut log_rx, mut event_rx } = client;
 //!     // Sync with the single script added
 //!     loop {
 //!         tokio::select! {
@@ -67,7 +67,7 @@
 //!             }
 //!         }
 //!     }
-//!     sender.shutdown().await;
+//!     requester.shutdown().await;
 //! }
 //! ```
 //!
@@ -126,7 +126,7 @@ pub use tokio::sync::mpsc::UnboundedReceiver;
 #[doc(inline)]
 pub use {
     crate::core::builder::NodeBuilder,
-    crate::core::client::{Client, EventSender},
+    crate::core::client::{Client, Requester},
     crate::core::error::{ClientError, NodeError},
     crate::core::messages::{Event, FailurePayload, Log, Progress, SyncUpdate, Warning},
     crate::core::node::{Node, NodeState},


### PR DESCRIPTION
The `EventSender` can do more than send events, and it is also unclear what exactly these events would be. A `Requester` is more clear in scope.