### PR TITLE
Separate `Warning` into its own channel, refactor transaction rejection naming

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -54,6 +54,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        warn_rx: _,
         mut event_rx,
     } = client;
 
@@ -62,10 +63,8 @@ async fn main() {
         tokio::select! {
             log = log_rx.recv() => {
                 if let Some(log) = log {
-                    match log {
-                        Log::Dialog(d) => tracing::info!("{d}"),
-                        Log::Warning(e) => tracing::warn!("{e}"),
-                        _ => (),
+                    if let Log::Dialog(log) = log {
+                        tracing::info!("{log}")
                     }
                 }
             }

--- a/example/rescan.rs
+++ b/example/rescan.rs
@@ -3,7 +3,7 @@
 //! blocks.
 
 use kyoto::{chain::checkpoints::HeaderCheckpoint, core::builder::NodeBuilder};
-use kyoto::{Address, Client, Event, Log, Network};
+use kyoto::{Address, Client, Event, Network};
 use std::collections::HashSet;
 use std::str::FromStr;
 
@@ -45,6 +45,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        mut warn_rx,
         mut event_rx,
     } = client;
     // Sync with the single script added
@@ -59,11 +60,12 @@ async fn main() {
             }
             log = log_rx.recv() => {
                 if let Some(log) = log {
-                    match log {
-                        Log::Dialog(d) => tracing::info!("{d}"),
-                        Log::Warning(warning) => tracing::warn!("{warning}"),
-                        _ => (),
-                    }
+                    tracing::info!("{log}");
+                }
+            }
+            warn = warn_rx.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}");
                 }
             }
         }
@@ -89,11 +91,12 @@ async fn main() {
             }
             log = log_rx.recv() => {
                 if let Some(log) = log {
-                    match log {
-                        Log::Dialog(d) => tracing::info!("{d}"),
-                        Log::Warning(warning) => tracing::warn!("{warning}"),
-                        _ => (),
-                    }
+                    tracing::info!("{log}");
+                }
+            }
+            warn = warn_rx.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}");
                 }
             }
         }

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -80,7 +80,6 @@ async fn main() {
                         Event::BlocksDisconnected(_) => {
                             tracing::warn!("Some blocks were reorganized")
                         },
-                        _ => (),
                     }
                 }
             }

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -57,6 +57,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        mut warn_rx,
         mut event_rx,
     } = client;
     // Continually listen for events until the node is synced to its peers.
@@ -87,11 +88,15 @@ async fn main() {
                 if let Some(log) = log {
                     match log {
                         Log::Dialog(d)=> tracing::info!("{d}"),
-                        Log::Warning(warning)=> tracing::warn!("{warning}"),
                         Log::StateChange(node_state) => tracing::info!("{node_state}"),
                         Log::ConnectionsMet => tracing::info!("All required connections met"),
                         _ => (),
                     }
+                }
+            }
+            warn = warn_rx.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}");
                 }
             }
         }

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -52,6 +52,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        mut warn_rx,
         mut event_rx,
     } = client;
     // Continually listen for events until the node is synced to its peers.
@@ -79,11 +80,15 @@ async fn main() {
                 if let Some(log) = log {
                     match log {
                         Log::Dialog(d)=> tracing::info!("{d}"),
-                        Log::Warning(warning)=> tracing::warn!("{warning}"),
                         Log::StateChange(node_state) => tracing::info!("{node_state}"),
                         Log::ConnectionsMet => tracing::info!("All required connections met"),
                         _ => (),
                     }
+                }
+            }
+            warn = warn_rx.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}");
                 }
             }
         }

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -72,7 +72,6 @@ async fn main() {
                         Event::BlocksDisconnected(_) => {
                             tracing::warn!("Some blocks were reorganized")
                         },
-                        _ => (),
                     }
                 }
             }

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -949,7 +949,7 @@ mod tests {
         },
         core::{
             dialog::Dialog,
-            messages::{Event, Log},
+            messages::{Event, Log, Warning},
         },
         filters::cfheader_chain::AppendAttempt,
     };
@@ -958,6 +958,7 @@ mod tests {
 
     fn new_regtest(anchor: HeaderCheckpoint) -> Chain<()> {
         let (log_tx, _) = tokio::sync::mpsc::channel::<Log>(1);
+        let (warn_tx, _) = tokio::sync::mpsc::unbounded_channel::<Warning>();
         let (event_tx, _) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let mut checkpoints = HeaderCheckpoints::new(&bitcoin::Network::Regtest);
         checkpoints.prune_up_to(anchor);
@@ -966,7 +967,7 @@ mod tests {
             HashSet::new(),
             anchor,
             checkpoints,
-            Dialog::new(log_tx, event_tx),
+            Dialog::new(log_tx, warn_tx, event_tx),
             (),
             1,
         )
@@ -974,6 +975,7 @@ mod tests {
 
     fn new_regtest_two_peers(anchor: HeaderCheckpoint) -> Chain<()> {
         let (log_tx, _) = tokio::sync::mpsc::channel::<Log>(1);
+        let (warn_tx, _) = tokio::sync::mpsc::unbounded_channel::<Warning>();
         let (event_tx, _) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let mut checkpoints = HeaderCheckpoints::new(&bitcoin::Network::Regtest);
         checkpoints.prune_up_to(anchor);
@@ -982,7 +984,7 @@ mod tests {
             HashSet::new(),
             anchor,
             checkpoints,
-            Dialog::new(log_tx, event_tx),
+            Dialog::new(log_tx, warn_tx, event_tx),
             (),
             2,
         )

--- a/src/core/channel_messages.rs
+++ b/src/core/channel_messages.rs
@@ -9,7 +9,7 @@ use bitcoin::{
     Block, BlockHash, FeeRate, Transaction,
 };
 
-use crate::core::messages::FailurePayload;
+use crate::core::messages::RejectPayload;
 
 #[derive(Debug, Clone)]
 pub(crate) enum MainThreadMessage {
@@ -49,7 +49,7 @@ pub(crate) enum PeerMessage {
     Filter(CFilter),
     Block(Block),
     NewBlocks(Vec<BlockHash>),
-    Reject(FailurePayload),
+    Reject(RejectPayload),
     Disconnect,
     Verack,
     Ping(u64),

--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, ops::Range, time::Duration};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 
-use crate::{Event, Log, TrustedPeer, TxBroadcast};
+use crate::{Event, Log, TrustedPeer, TxBroadcast, Warning};
 
 #[cfg(feature = "filter-control")]
 use super::{error::FetchBlockError, messages::BlockRequest, BlockReceiver, IndexedBlock};
@@ -24,6 +24,8 @@ pub struct Client {
     pub requester: Requester,
     /// Receive log messages from a node.
     pub log_rx: mpsc::Receiver<Log>,
+    /// Receive warning messages from a node.
+    pub warn_rx: mpsc::UnboundedReceiver<Warning>,
     /// Receive [`Event`] from a node to act on.
     pub event_rx: mpsc::UnboundedReceiver<Event>,
 }
@@ -31,12 +33,14 @@ pub struct Client {
 impl Client {
     pub(crate) fn new(
         log_rx: mpsc::Receiver<Log>,
+        warn_rx: mpsc::UnboundedReceiver<Warning>,
         event_rx: mpsc::UnboundedReceiver<Event>,
         ntx: Sender<ClientMessage>,
     ) -> Self {
         Self {
             requester: Requester::new(ntx),
             log_rx,
+            warn_rx,
             event_rx,
         }
     }
@@ -351,13 +355,15 @@ mod tests {
     async fn test_client_works() {
         let transaction: Transaction = deserialize(&hex::decode("0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000").unwrap()).unwrap();
         let (log_tx, log_rx) = tokio::sync::mpsc::channel::<Log>(1);
+        let (_, warn_rx) = tokio::sync::mpsc::unbounded_channel::<Warning>();
         let (_, event_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
         let Client {
             requester,
             mut log_rx,
+            warn_rx: _,
             event_rx: _,
-        } = Client::new(log_rx, event_rx, ctx);
+        } = Client::new(log_rx, warn_rx, event_rx, ctx);
         let send_res = log_tx
             .send(Log::Dialog("An important message".into()))
             .await;

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -5,12 +5,21 @@ use super::messages::{Event, Log, Progress, Warning};
 #[derive(Debug, Clone)]
 pub(crate) struct Dialog {
     log_tx: Sender<Log>,
+    warn_tx: UnboundedSender<Warning>,
     event_tx: UnboundedSender<Event>,
 }
 
 impl Dialog {
-    pub(crate) fn new(log_tx: Sender<Log>, event_tx: UnboundedSender<Event>) -> Self {
-        Self { log_tx, event_tx }
+    pub(crate) fn new(
+        log_tx: Sender<Log>,
+        warn_tx: UnboundedSender<Warning>,
+        event_tx: UnboundedSender<Event>,
+    ) -> Self {
+        Self {
+            log_tx,
+            warn_tx,
+            event_tx,
+        }
     }
 
     pub(crate) async fn send_dialog(&self, dialog: impl Into<String>) {
@@ -40,7 +49,7 @@ impl Dialog {
     }
 
     pub(crate) async fn send_warning(&self, warning: Warning) {
-        let _ = self.log_tx.send(Log::Warning(warning)).await;
+        let _ = self.warn_tx.send(warning);
     }
 
     pub(crate) async fn send_info(&self, info: Log) {

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -48,7 +48,7 @@ impl Dialog {
         let _ = self.log_tx.send(Log::Dialog(message)).await;
     }
 
-    pub(crate) async fn send_warning(&self, warning: Warning) {
+    pub(crate) fn send_warning(&self, warning: Warning) {
         let _ = self.warn_tx.send(warning);
     }
 

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -62,8 +62,6 @@ pub enum Event {
     Synced(SyncUpdate),
     /// Blocks were reorganized out of the chain.
     BlocksDisconnected(Vec<DisconnectedHeader>),
-    /// A problem occured sending a transaction. Either the remote node disconnected or the transaction was rejected.
-    TxBroadcastFailure(RejectPayload),
     /// A compact block filter with associated height and block hash.
     #[cfg(feature = "filter-control")]
     IndexedFilter(IndexedFilter),

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -63,7 +63,7 @@ pub enum Event {
     /// Blocks were reorganized out of the chain.
     BlocksDisconnected(Vec<DisconnectedHeader>),
     /// A problem occured sending a transaction. Either the remote node disconnected or the transaction was rejected.
-    TxBroadcastFailure(FailurePayload),
+    TxBroadcastFailure(RejectPayload),
     /// A compact block filter with associated height and block hash.
     #[cfg(feature = "filter-control")]
     IndexedFilter(IndexedFilter),
@@ -132,14 +132,14 @@ impl Progress {
 
 /// An attempt to broadcast a tranasction failed.
 #[derive(Debug, Clone, Copy)]
-pub struct FailurePayload {
+pub struct RejectPayload {
     /// An enumeration of the reason for the transaction failure. If none is provided, the message could not be sent over the wire.
     pub reason: Option<RejectReason>,
     /// The transaction that was rejected or failed to broadcast.
     pub txid: Txid,
 }
 
-impl FailurePayload {
+impl RejectPayload {
     pub(crate) fn from_txid(txid: Txid) -> Self {
         Self { reason: None, txid }
     }

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -245,7 +245,7 @@ pub enum Warning {
     /// The headers in the database do not link together. Recoverable by deleting the database.
     CorruptedHeaders,
     /// A transaction got rejected, likely for being an insufficient fee or non-standard transaction.
-    TransactionRejected,
+    TransactionRejected(RejectPayload),
     /// A database failed to persist some data.
     FailedPersistance {
         /// Additional context for the persistance failure.
@@ -286,7 +286,9 @@ impl core::fmt::Display for Warning {
                     "The node has been running for a long duration without receiving new blocks."
                 )
             }
-            Warning::TransactionRejected => write!(f, "A transaction got rejected."),
+            Warning::TransactionRejected(r) => {
+                write!(f, "A transaction got rejected: TXID {}", r.txid)
+            }
             Warning::FailedPersistance { warning } => {
                 write!(f, "A database failed to persist some data: {}", warning)
             }

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -21,8 +21,6 @@ use super::{
 pub enum Log {
     /// Human readable dialog of what the node is currently doing.
     Dialog(String),
-    /// A warning that may effect the function of the node.
-    Warning(Warning),
     /// The current state of the node in the syncing process.
     StateChange(NodeState),
     /// The node is connected to all required peers.
@@ -39,7 +37,6 @@ impl core::fmt::Display for Log {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Log::Dialog(d) => write!(f, "{}", d),
-            Log::Warning(w) => write!(f, "{}", w),
             Log::StateChange(s) => write!(f, "{}", s),
             Log::TxSent(txid) => write!(f, "Transaction sent: {}", txid),
             Log::ConnectionsMet => write!(f, "Required connections met"),

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -261,7 +261,6 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                 PeerMessage::Reject(payload) => {
                                     self.dialog
                                         .send_warning(Warning::TransactionRejected(payload)).await;
-                                    self.dialog.send_event(Event::TxBroadcastFailure(payload)).await;
                                 }
                                 PeerMessage::FeeFilter(feerate) => {
                                     let mut peer_map = self.peer_map.lock().await;
@@ -419,7 +418,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                     self.dialog.send_info(Log::TxSent(txid)).await;
                 } else {
                     self.dialog
-                        .send_event(Event::TxBroadcastFailure(RejectPayload::from_txid(txid)))
+                        .send_warning(Warning::TransactionRejected(RejectPayload::from_txid(txid)))
                         .await;
                 }
             }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -24,7 +24,7 @@ use crate::{
     core::{error::FetchHeaderError, peer_map::PeerMap},
     db::traits::{HeaderStore, PeerStore},
     filters::{cfheader_chain::AppendAttempt, error::CFilterSyncError},
-    ConnectionType, FailurePayload, PeerStoreSizeConfig, TrustedPeer, TxBroadcastPolicy,
+    ConnectionType, PeerStoreSizeConfig, RejectPayload, TrustedPeer, TxBroadcastPolicy,
 };
 
 use super::{
@@ -419,7 +419,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                     self.dialog.send_info(Log::TxSent(txid)).await;
                 } else {
                     self.dialog
-                        .send_event(Event::TxBroadcastFailure(FailurePayload::from_txid(txid)))
+                        .send_event(Event::TxBroadcastFailure(RejectPayload::from_txid(txid)))
                         .await;
                 }
             }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -93,11 +93,12 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     ) -> (Self, Client) {
         // Set up a communication channel between the node and client
         let (log_tx, log_rx) = mpsc::channel::<Log>(32);
+        let (warn_tx, warn_rx) = mpsc::unbounded_channel::<Warning>();
         let (event_tx, event_rx) = mpsc::unbounded_channel::<Event>();
         let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
-        let client = Client::new(log_rx, event_rx, ctx);
+        let client = Client::new(log_rx, warn_rx, event_rx, ctx);
         // A structured way to talk to the client
-        let dialog = Dialog::new(log_tx, event_tx);
+        let dialog = Dialog::new(log_tx, warn_tx, event_tx);
         // We always assume we are behind
         let state = Arc::new(RwLock::new(NodeState::Behind));
         // Configure the peer manager

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -260,7 +260,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                 }
                                 PeerMessage::Reject(payload) => {
                                     self.dialog
-                                        .send_warning(Warning::TransactionRejected).await;
+                                        .send_warning(Warning::TransactionRejected(payload)).await;
                                     self.dialog.send_event(Event::TxBroadcastFailure(payload)).await;
                                 }
                                 PeerMessage::FeeFilter(feerate) => {

--- a/src/core/peer_map.rs
+++ b/src/core/peer_map.rs
@@ -287,7 +287,7 @@ impl<P: PeerStore> PeerMap<P> {
             peer_manager.num_unbanned().await?
         };
         if current_count < 1 {
-            self.dialog.send_warning(Warning::EmptyPeerDatabase).await;
+            self.dialog.send_warning(Warning::EmptyPeerDatabase);
             #[cfg(feature = "dns")]
             self.bootstrap().await?;
         }
@@ -334,14 +334,12 @@ impl<P: PeerStore> PeerMap<P> {
                 ))
                 .await
             {
-                self.dialog
-                    .send_warning(Warning::FailedPersistance {
-                        warning: format!(
-                            "Encountered an error adding {:?}:{} flags: {} ... {e}",
-                            peer.addr, peer.port, peer.services
-                        ),
-                    })
-                    .await;
+                self.dialog.send_warning(Warning::FailedPersistance {
+                    warning: format!(
+                        "Encountered an error adding {:?}:{} flags: {} ... {e}",
+                        peer.addr, peer.port, peer.services
+                    ),
+                });
             }
         }
     }
@@ -359,14 +357,12 @@ impl<P: PeerStore> PeerMap<P> {
                 ))
                 .await
             {
-                self.dialog
-                    .send_warning(Warning::FailedPersistance {
-                        warning: format!(
-                            "Encountered an error adding {:?}:{} flags: {} ... {e}",
-                            peer.address, peer.port, peer.service_flags
-                        ),
-                    })
-                    .await;
+                self.dialog.send_warning(Warning::FailedPersistance {
+                    warning: format!(
+                        "Encountered an error adding {:?}:{} flags: {} ... {e}",
+                        peer.address, peer.port, peer.service_flags
+                    ),
+                });
             }
         }
     }
@@ -384,14 +380,12 @@ impl<P: PeerStore> PeerMap<P> {
                 ))
                 .await
             {
-                self.dialog
-                    .send_warning(Warning::FailedPersistance {
-                        warning: format!(
-                            "Encountered an error adding {:?}:{} flags: {} ... {e}",
-                            peer.address, peer.port, peer.service_flags
-                        ),
-                    })
-                    .await;
+                self.dialog.send_warning(Warning::FailedPersistance {
+                    warning: format!(
+                        "Encountered an error adding {:?}:{} flags: {} ... {e}",
+                        peer.address, peer.port, peer.service_flags
+                    ),
+                });
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@
 //!     // Run the node and wait for the sync message;
 //!     tokio::task::spawn(async move { node.run().await });
 //!     // Split the client into components that send messages and listen to messages
-//!     let Client { requester, mut log_rx, mut event_rx } = client;
+//!     let Client { requester, mut log_rx, warn_rx: _, mut event_rx } = client;
 //!     // Sync with the single script added
 //!     loop {
 //!         tokio::select! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub use {
     crate::core::builder::NodeBuilder,
     crate::core::client::{Client, Requester},
     crate::core::error::{ClientError, NodeError},
-    crate::core::messages::{Event, FailurePayload, Log, Progress, SyncUpdate, Warning},
+    crate::core::messages::{Event, Log, Progress, RejectPayload, SyncUpdate, Warning},
     crate::core::node::{Node, NodeState},
 };
 

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -100,7 +100,7 @@ impl Peer {
                 self.dialog
                     .send_dialog(format!("Failed to establish an encrypted connection: {e}"))
                     .await;
-                self.dialog.send_warning(Warning::CouldNotConnect).await;
+                self.dialog.send_warning(Warning::CouldNotConnect);
             }
             let (decryptor, encryptor) = handshake_result?;
             let message_mutex: MutexMessageGenerator =
@@ -140,11 +140,11 @@ impl Peer {
                 return Ok(());
             }
             if self.message_counter.unsolicited() {
-                self.dialog.send_warning(Warning::UnsolicitedMessage).await;
+                self.dialog.send_warning(Warning::UnsolicitedMessage);
                 return Ok(());
             }
             if self.message_counter.unresponsive() {
-                self.dialog.send_warning(Warning::PeerTimedOut).await;
+                self.dialog.send_warning(Warning::PeerTimedOut);
                 return Ok(());
             }
             if Instant::now().duration_since(start_time) > self.timeout_config.max_connection_time {

--- a/src/network/reader.rs
+++ b/src/network/reader.rs
@@ -6,7 +6,7 @@ use bitcoin::{FeeRate, Txid};
 use tokio::sync::mpsc::Sender;
 
 use crate::core::channel_messages::{CombinedAddr, PeerMessage};
-use crate::core::messages::FailurePayload;
+use crate::core::messages::RejectPayload;
 
 use super::error::PeerReadError;
 use super::traits::MessageParser;
@@ -133,7 +133,7 @@ impl Reader {
             NetworkMessage::Alert(_) => None,
             NetworkMessage::Reject(rejection) => {
                 let txid = Txid::from(rejection.hash);
-                Some(PeerMessage::Reject(FailurePayload {
+                Some(PeerMessage::Reject(RejectPayload {
                     reason: Some(rejection.ccode),
                     txid,
                 }))

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -127,11 +127,7 @@ async fn sync_assert(
             }
             log = log.recv() => {
                 if let Some(log) = log {
-                    match log {
-                        Log::Dialog(d) => println!("{d}"),
-                        Log::Warning(warning) => println!("{warning}"),
-                        _ => (),
-                    }
+                    println!("{log}");
                 }
             }
         }
@@ -161,6 +157,7 @@ async fn test_reorg() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
@@ -213,6 +210,7 @@ async fn test_mine_after_reorg() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
@@ -268,6 +266,7 @@ async fn test_various_client_methods() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
@@ -305,6 +304,7 @@ async fn test_sql_reorg() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
@@ -323,6 +323,7 @@ async fn test_sql_reorg() {
     let Client {
         requester,
         log_rx: _,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // Make sure the reorganization is caught after a cold start
@@ -351,6 +352,7 @@ async fn test_sql_reorg() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // The node properly syncs after persisting a reorg
@@ -382,6 +384,7 @@ async fn test_two_deep_reorg() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
@@ -400,6 +403,7 @@ async fn test_two_deep_reorg() {
     let Client {
         requester,
         log_rx: _,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     while let Some(message) = channel.recv().await {
@@ -427,6 +431,7 @@ async fn test_two_deep_reorg() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // The node properly syncs after persisting a reorg
@@ -457,6 +462,7 @@ async fn test_sql_stale_anchor() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     sync_assert(&best, &mut channel, &mut log).await;
@@ -479,6 +485,7 @@ async fn test_sql_stale_anchor() {
     let Client {
         requester,
         log_rx: _,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // Ensure SQL is able to catch the fork by loading in headers from the database
@@ -514,6 +521,7 @@ async fn test_sql_stale_anchor() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // The node properly syncs after persisting a reorg
@@ -536,6 +544,7 @@ async fn test_sql_stale_anchor() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // The node properly syncs after persisting a reorg
@@ -575,13 +584,13 @@ async fn test_halting_works() {
     let Client {
         requester,
         log_rx: mut log,
+        warn_rx: _,
         event_rx: mut channel,
     } = client;
     // Ensure SQL is able to catch the fork by loading in headers from the database
     while let Some(message) = log.recv().await {
         match message {
             Log::Dialog(d) => println!("{d}"),
-            Log::Warning(warning) => println!("{warning}"),
             Log::StateChange(node_state) => {
                 if let NodeState::FilterHeadersSynced = node_state {
                     println!("Sleeping for one second...");
@@ -632,11 +641,12 @@ async fn test_signet_syncs() {
                 }
                 log = client.log_rx.recv() => {
                     if let Some(log) = log {
-                        match log {
-                            Log::Dialog(d) => println!("{d}"),
-                            Log::Warning(warning) => tracing::warn!("{warning}"),
-                            _ => (),
-                        }
+                        println!("{log}");
+                    }
+                }
+                warn = client.warn_rx.recv() => {
+                    if let Some(warn) = warn {
+                        println!("{warn}")
                     }
                 }
             }


### PR DESCRIPTION
Previous to this PR, the relationship between `Log` and `Warning` is that a `Warning` is contained in a `Log`. Because the log channel had limited capacity, a `Warning` event can technically be missed if the receiver is lagging behind. To compensate for this, transaction rejections at the network level were put into the `Event` enum, which have an unbounded channel to miss any `Event`. In reality though, a user would probably not want to miss any `Warning` at all, including transaction rejections. 

As an aside, the term "failure" in `FailurePayload` is not correct, as a single node may reject a transaction while others accept it. Instead, the `FailurePayload` is renamed to `RejectPayload` to more accurately reflect the situation.

This PR introduces the `RejectPayload` into the transaction rejection variant on `Warning`. In addition, the `Warning` variant is removed from `Log`, and `Warning` events are given their own channel. Now there is a clear separation of concerns between a `Log`, `Warning`, and `Event` without ambiguity of what data should be in each type.

@nyonson the bulk of the refactor are one line changes to account for this new warning channel sender/receiver. I tried to break the commits into easily reviewable parts, minus the head commit that has to do some heavy lifting. Of note in that one, any time the node needs to talk to the client, it must do so through the `Dialog`  struct. To redirect the `Warning` messages to the new channel instead of with `Log`, all that changes is the implementation of `Dialog::send_warning`.