### PR TITLE
Remove VSCode IDE configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /kyoto
 .DS_Store
 .idea/
+/.vscode
 src/.DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-    "recommendations": [
-        "rust-lang.rust-analyzer",
-        "tamasfe.even-better-toml",
-        "usernamehw.errorlens",
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": true
-}


### PR DESCRIPTION
Bitcoin Core has the philosophy that IDE related files and folders should be ignored. Recently became relevant when my configurations conflicted with a BDK developers dev environment in VS Code. Removing this IDE specific folder here.