### PR TITLE
Remove async from `send_event`

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -460,9 +460,7 @@ impl<H: HeaderStore> Chain<H> {
                 self.cf_header_chain.remove(removed_hashes);
                 self.filter_chain.remove(removed_hashes);
                 self.block_queue.remove(removed_hashes);
-                self.dialog
-                    .send_event(Event::BlocksDisconnected(reorged))
-                    .await;
+                self.dialog.send_event(Event::BlocksDisconnected(reorged));
                 self.flush_over_height(stem).await;
                 Ok(())
             } else {
@@ -747,9 +745,7 @@ impl<H: HeaderStore> Chain<H> {
                 .await
                 .ok_or(CFilterSyncError::UnknownFilterHash)?;
             let indexed_filter = IndexedFilter::new(height, filter);
-            self.dialog
-                .send_event(Event::IndexedFilter(indexed_filter))
-                .await;
+            self.dialog.send_event(Event::IndexedFilter(indexed_filter));
         }
 
         #[cfg(not(feature = "filter-control"))]
@@ -845,8 +841,7 @@ impl<H: HeaderStore> Chain<H> {
             }
             None => {
                 self.dialog
-                    .send_event(Event::Block(IndexedBlock::new(height, block)))
-                    .await;
+                    .send_event(Event::Block(IndexedBlock::new(height, block)));
             }
         }
         Ok(())

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -56,7 +56,7 @@ impl Dialog {
         let _ = self.log_tx.send(info).await;
     }
 
-    pub(crate) async fn send_event(&self, message: Event) {
+    pub(crate) fn send_event(&self, message: Event) {
         let _ = self.event_tx.send(message);
     }
 }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -466,7 +466,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                     self.dialog
                         .send_info(Log::StateChange(NodeState::TransactionsSynced))
                         .await;
-                    let _ = self.dialog.send_event(Event::Synced(update)).await;
+                    self.dialog.send_event(Event::Synced(update));
                 }
             }
             NodeState::TransactionsSynced => {


### PR DESCRIPTION
`Dialog::send_event` also makes use of the unbounded mpsc channels. From the docs:
> This method is not marked async because sending a message to an unbounded channel never requires any form of waiting.

There is no need to wait for more room on the stack or heap because the unbounded channels don't have a designated memory space. The bounded channels have to wait for sending an item because there may or may not be space in the channel. Conceptually a "channel" is just a queue in memory with one type that may place things there and another that can take things. 

Follows up to the previous `send_warning` refactor @nyonson 