### PR TITLE
Drop cargo configs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,0 @@
-# uncomment to use tokio-console
-
-# [build]
-# rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,7 @@ tracing-subscriber = "0.3"
 tempfile = "3"
 tokio = { version = "1.37", default-features = false, features = [
     "full",
-] } # add feature "tracing" to use the console
-# Enable the tokio-console task and poll observations
-# console-subscriber = "0.3.0"
+] }
 
 [lib]
 name = "kyoto"


### PR DESCRIPTION
Instead of relying on dirty-ing a checked in file (`.cargo/config.toml`), switch to a feature flag based flow to enable the tokio debug console. This avoids accidental thrashing in the checked in file. It also allows a discoverable path from the justfile for new developers.

This is my first foray into the `build.rs` system, but it seems pretty straightforward. Also trying to be better about conventional commit messages.

Edit: Dropped all changes except for removing the cargo configs for now.