### PR TITLE
Remove invalid check for MTP during fork

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -372,9 +372,11 @@ impl<H: HeaderStore> Chain<H> {
 
         // The headers have times that are greater than the median of the previous 11 blocks
         let mut last_relevant_mtp = self.header_chain.last_median_time_past_window();
-        if !header_batch
-            .valid_median_time_past(&mut last_relevant_mtp)
-            .await
+        // If this batch does not extend from the current tip, the headers provided by `last_median_time_past_window` are invalid
+        if self.tip().eq(&header_batch.first().prev_blockhash)
+            && !header_batch
+                .valid_median_time_past(&mut last_relevant_mtp)
+                .await
         {
             // The first validation may be incorrect because of median miscalculation,
             // but it is cheap to detect the peer is lying later from checkpoints

--- a/src/chain/header_batch.rs
+++ b/src/chain/header_batch.rs
@@ -56,15 +56,12 @@ impl HeadersBatch {
     // Do the blocks pass the time requirements
     pub(crate) async fn valid_median_time_past(&self, previous_buffer: &mut Vec<Header>) -> bool {
         previous_buffer.extend_from_slice(&self.batch);
-        let median_times: Vec<u32> = previous_buffer
+        previous_buffer
             .windows(MEDIAN_TIME_PAST)
             .map(|window| window.iter().map(|block| block.time).collect::<Vec<_>>())
             .map(|mut times| times.median())
-            .collect();
-        median_times
-            .iter()
             .zip(&self.batch)
-            .all(|(median, header)| header.time >= *median)
+            .all(|(median, header)| header.time >= median)
     }
 
     // The tip of the list


### PR DESCRIPTION
The `last_median_time_past_window` function assumes we are trying to extend the current chain with the new headers we receive. Before this patch, in `sanity_check` the MTP was evaluated even in a fork scenario, which is not a valid MTP check.

@nyonson blending a refactor with a functional change here but removing the variable reassignment is not too bad to track in the diff. Trying to make the iterator easier to reason about.