### PR TITLE
Update stale block time after resetting connections

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -48,7 +48,7 @@ impl LastBlockMonitor {
         Self { last_block: None }
     }
 
-    pub(crate) fn update(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.last_block = Some(Instant::now())
     }
 


### PR DESCRIPTION
If a block is considered stale, the `advance_state` function will reset connections with all peers. To reset the "staleness" of a block, the `LastBlockMonitor::update` function must be called. Currently that is done upon receiving new block headers, but no headers will ever be sent, as `advance_state` disconnects the peers before they can send them. That causes a loop that makes no progress. Here we patch this to reset the "staleness" of a block after disconnecting from all peers.

For context, the `LastBlockMonitor` is used to prevent a block withholding attack, where all connected peers refuse to advertise new blocks to us. After 30 minutes if there is no block found, we open new connections to see if there was a block being withheld. @nyonson 