### PR TITLE
Remove the MTP check

### DIFF
--- a/src/chain/header_batch.rs
+++ b/src/chain/header_batch.rs
@@ -2,10 +2,7 @@ use std::ops::RangeFrom;
 
 use bitcoin::{block::Header, params::Params, Target};
 
-use crate::{
-    impl_sourceless_error,
-    prelude::{Median, MEDIAN_TIME_PAST},
-};
+use crate::impl_sourceless_error;
 
 pub(crate) struct HeadersBatch {
     batch: Vec<Header>,
@@ -51,17 +48,6 @@ impl HeadersBatch {
                 let transition = Target::from_compact(first.bits).max_transition_threshold(params);
                 Target::from_compact(second.bits).le(&transition)
             })
-    }
-
-    // Do the blocks pass the time requirements
-    pub(crate) async fn valid_median_time_past(&self, previous_buffer: &mut Vec<Header>) -> bool {
-        previous_buffer.extend_from_slice(&self.batch);
-        previous_buffer
-            .windows(MEDIAN_TIME_PAST)
-            .map(|window| window.iter().map(|block| block.time).collect::<Vec<_>>())
-            .map(|mut times| times.median())
-            .zip(&self.batch)
-            .all(|(median, header)| header.time >= median)
     }
 
     // The tip of the list

--- a/src/chain/header_chain.rs
+++ b/src/chain/header_chain.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use bitcoin::{block::Header, BlockHash, Work};
 
-use crate::{prelude::MEDIAN_TIME_PAST, DisconnectedHeader};
+use crate::DisconnectedHeader;
 
 use super::checkpoints::HeaderCheckpoint;
 
@@ -134,17 +134,6 @@ impl HeaderChain {
             .map(|header| header.work().log2())
             .reduce(|acc, next| acc + next);
         work.unwrap_or(0.0)
-    }
-
-    // The last 11 headers, if we have that many
-    pub(crate) fn last_median_time_past_window(&self) -> Vec<Header> {
-        self.headers
-            .values()
-            .rev()
-            .take(MEDIAN_TIME_PAST)
-            .rev()
-            .copied()
-            .collect()
     }
 
     // The block locators are a way to inform our peer of blocks we know about

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,6 +4,7 @@ use bitcoin::{hex::DisplayHex, p2p::address::AddrV2, Network};
 
 #[allow(dead_code)]
 pub const MAX_FUTURE_BLOCK_TIME: i64 = 60 * 60 * 2;
+#[allow(unused)]
 pub const MEDIAN_TIME_PAST: usize = 11;
 
 pub(crate) type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;


### PR DESCRIPTION
The current MTP check is hard to reason about and caused syncing issues over Testnet4. In a greater effort to refactor how `HEADERS` messages are evaluated, I am opting to remove the MTP check and add it back later if deemed worthwhile.

Closes #265 

cc @nyonson 