### PR TITLE
Make CPU bound tasks synchronous in `Chain`

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -318,7 +318,7 @@ impl<H: HeaderStore> Chain<H> {
             return Ok(());
         }
         // We check first if the peer is sending us nonsense
-        self.sanity_check(&header_batch).await?;
+        self.sanity_check(&header_batch)?;
         // How we handle forks depends on if we are caught up through all checkpoints or not
         match self.checkpoints.next().cloned() {
             Some(checkpoint) => {
@@ -346,7 +346,7 @@ impl<H: HeaderStore> Chain<H> {
     }
 
     // These are invariants in all batches of headers we receive
-    async fn sanity_check(&mut self, header_batch: &HeadersBatch) -> Result<(), HeaderSyncError> {
+    fn sanity_check(&mut self, header_batch: &HeadersBatch) -> Result<(), HeaderSyncError> {
         let initially_syncing = !self.checkpoints.is_exhausted();
         // Some basic sanity checks that should result in peer bans on errors
 
@@ -356,16 +356,16 @@ impl<H: HeaderStore> Chain<H> {
         }
 
         // All the headers connect with each other and is the difficulty adjustment not absurd
-        if !header_batch.connected().await {
+        if !header_batch.connected() {
             return Err(HeaderSyncError::HeadersNotConnected);
         }
 
         // All headers pass their own proof of work and the network minimum
-        if !header_batch.individually_valid_pow().await {
+        if !header_batch.individually_valid_pow() {
             return Err(HeaderSyncError::InvalidHeaderWork);
         }
 
-        if !header_batch.bits_adhere_transition(self.network).await {
+        if !header_batch.bits_adhere_transition(self.network) {
             return Err(HeaderSyncError::InvalidBits);
         }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -106,7 +106,7 @@ impl<H: HeaderStore> Chain<H> {
 
     // This header chain contains a block hash, potentially checking the disk
     pub(crate) async fn height_of_hash(&self, blockhash: BlockHash) -> Option<u32> {
-        match self.header_chain.height_of_hash(blockhash).await {
+        match self.header_chain.height_of_hash(blockhash) {
             Some(height) => Some(height),
             None => {
                 let mut lock = self.db.lock().await;

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -750,7 +750,7 @@ impl<H: HeaderStore> Chain<H> {
                 .await;
         }
 
-        self.filter_chain.put_hash(filter_message.block_hash).await;
+        self.filter_chain.put_hash(filter_message.block_hash);
         let stop_hash = self
             .filter_chain
             .last_stop_hash_request()
@@ -890,8 +890,8 @@ impl<H: HeaderStore> Chain<H> {
     }
 
     // Clear the filter header cache to rescan the filters for new scripts.
-    pub(crate) async fn clear_filters(&mut self) {
-        self.filter_chain.clear_cache().await;
+    pub(crate) fn clear_filters(&mut self) {
+        self.filter_chain.clear_cache();
     }
 }
 

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -628,10 +628,10 @@ impl<H: HeaderStore> Chain<H> {
         self.audit_cf_headers(&batch).await?;
         // We already have a message like this. Verify they are the same
         match self.cf_header_chain.merged_queue.take() {
-            Some(queue) => Ok(self.cf_header_chain.verify(&mut batch, queue).await),
+            Some(queue) => Ok(self.cf_header_chain.verify(&mut batch, queue)),
             None => {
                 let queue = self.construct_cf_header_queue(&mut batch).await?;
-                Ok(self.cf_header_chain.set_queue(queue).await)
+                Ok(self.cf_header_chain.set_queue(queue))
             }
         }
     }

--- a/src/chain/header_batch.rs
+++ b/src/chain/header_batch.rs
@@ -19,7 +19,7 @@ impl HeadersBatch {
     }
 
     // Are they all logically connected?
-    pub(crate) async fn connected(&self) -> bool {
+    pub(crate) fn connected(&self) -> bool {
         self.batch
             .iter()
             .zip(self.batch.iter().skip(1))
@@ -27,7 +27,7 @@ impl HeadersBatch {
     }
 
     // Are all the blocks of sufficient work and meet their own target?
-    pub(crate) async fn individually_valid_pow(&self) -> bool {
+    pub(crate) fn individually_valid_pow(&self) -> bool {
         !self.batch.iter().any(|header| {
             let target = header.target();
             let valid_pow = header.validate_pow(target);
@@ -36,7 +36,7 @@ impl HeadersBatch {
     }
 
     // Do the targets not change drastically within the batch?
-    pub(crate) async fn bits_adhere_transition(&self, params: impl AsRef<Params>) -> bool {
+    pub(crate) fn bits_adhere_transition(&self, params: impl AsRef<Params>) -> bool {
         let params = params.as_ref();
         if params.allow_min_difficulty_blocks {
             return true;

--- a/src/chain/header_chain.rs
+++ b/src/chain/header_chain.rs
@@ -72,7 +72,7 @@ impl HeaderChain {
     }
 
     // The height of the blockhash in the chain
-    pub(crate) async fn height_of_hash(&self, blockhash: BlockHash) -> Option<Height> {
+    pub(crate) fn height_of_hash(&self, blockhash: BlockHash) -> Option<Height> {
         if blockhash.eq(&self.anchor_checkpoint.hash) {
             return Some(self.anchor_checkpoint.height);
         }
@@ -411,7 +411,7 @@ mod tests {
             chain.values()
         );
         assert_eq!(chain.header_at_height(3), Some(&block_3));
-        let want = chain.height_of_hash(new_block_2.block_hash()).await;
+        let want = chain.height_of_hash(new_block_2.block_hash());
         assert_eq!(Some(2), want);
     }
 }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -766,7 +766,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             NodeState::Behind => None,
             NodeState::HeadersSynced => None,
             _ => {
-                chain.clear_filters().await;
+                chain.clear_filters();
                 self.dialog
                     .send_info(Log::StateChange(NodeState::FilterHeadersSynced))
                     .await;

--- a/src/filters/cfheader_chain.rs
+++ b/src/filters/cfheader_chain.rs
@@ -81,13 +81,13 @@ impl CFHeaderChain {
     }
 
     // Set a reference point for the block hashes and associated filter hash.
-    pub(crate) async fn set_queue(&mut self, cf_headers: Vec<QueuedCFHeader>) -> AppendAttempt {
+    pub(crate) fn set_queue(&mut self, cf_headers: Vec<QueuedCFHeader>) -> AppendAttempt {
         self.current_quorum += 1;
-        self.attempt_merge(cf_headers).await
+        self.attempt_merge(cf_headers)
     }
 
     // Verify a batch of filter headers and hashes is what we expect.
-    pub(crate) async fn verify(
+    pub(crate) fn verify(
         &mut self,
         cf_headers: &mut CFHeaderBatch,
         queue: Vec<QueuedCFHeader>,
@@ -105,11 +105,11 @@ impl CFHeaderChain {
             }
         }
         self.current_quorum += 1;
-        self.attempt_merge(queue).await
+        self.attempt_merge(queue)
     }
 
     // If enough peers have responded, insert those block hashes and filter hashes into a map.
-    async fn attempt_merge(&mut self, queue: Vec<QueuedCFHeader>) -> AppendAttempt {
+    fn attempt_merge(&mut self, queue: Vec<QueuedCFHeader>) -> AppendAttempt {
         if self.current_quorum.ge(&self.quorum_required) {
             for (block_hash, filter_hash) in queue.iter().map(|queue| queue.hash_tuple()) {
                 self.hash_chain.insert(block_hash, filter_hash);

--- a/src/filters/filter_chain.rs
+++ b/src/filters/filter_chain.rs
@@ -26,7 +26,7 @@ impl FilterChain {
         }
     }
 
-    pub(crate) async fn put_hash(&mut self, hash: BlockHash) {
+    pub(crate) fn put_hash(&mut self, hash: BlockHash) {
         self.chain.insert(hash);
     }
 
@@ -37,7 +37,7 @@ impl FilterChain {
         }
     }
 
-    pub(crate) async fn clear_cache(&mut self) {
+    pub(crate) fn clear_cache(&mut self) {
         self.chain.clear()
     }
 


### PR DESCRIPTION
From my original understanding of `async` runtimes I thought you could slap an `async` on anything you expect to take some time to complete. After further reading, I don't think this is the correct approach for CPU-bound work that does not benefit from concurrency (unless by use of multiple threads but that is besides the point here). The additional context switching of adding a future that may or may not poll as ready might even add some overhead. Here I remove the `async` from CPU-bound functions to remove any unnecessary context switching.

Happy to let this one marinate for a little if there is some interest in actually profiling if this does anything. Although I don't think there will be any noticeable effect, I think it is good practice to remove the `async` from these functions. 

ref:  https://users.rust-lang.org/t/should-you-only-use-futures-for-i-o-bound-tasks/100784

cc @nyonson 