### PR TITLE
Remove `dns` feature and enable DNS by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,8 @@ arti-client = { version = "0.21.0", features = [
 tor-rtcompat = { version = "0.21.0", features = ["tokio"], optional = true }
 
 [features]
-default = ["database", "dns"]
+default = ["database"]
 database = ["rusqlite"]
-dns = []
 tor = ["arti-client", "tor-rtcompat"]
 filter-control = []
 

--- a/src/core/peer_map.rs
+++ b/src/core/peer_map.rs
@@ -288,7 +288,6 @@ impl<P: PeerStore> PeerMap<P> {
         };
         if current_count < 1 {
             self.dialog.send_warning(Warning::EmptyPeerDatabase);
-            #[cfg(feature = "dns")]
             self.bootstrap().await?;
         }
         let mut peer_manager = self.db.lock().await;
@@ -390,7 +389,6 @@ impl<P: PeerStore> PeerMap<P> {
         }
     }
 
-    #[cfg(feature = "dns")]
     async fn bootstrap(&mut self) -> Result<(), PeerManagerError<P::Error>> {
         use crate::network::dns::Dns;
         use std::net::IpAddr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,6 @@
 //!
 //! # Features
 //!
-//! `dns`: if no peers are provided, query DNS seeds for Bitcoin nodes to connect to. Default and recommend feature.
-//!
 //! `database`: use the default `rusqlite` database implementations. Default and recommend feature.
 //!
 //! `filter-control`: check filters and request blocks directly. Recommended for silent payments or strict chain ordering implementations.

--- a/src/network/dns.rs
+++ b/src/network/dns.rs
@@ -59,13 +59,11 @@ const A_RECORD: u16 = 0x01;
 const A_CLASS: u16 = 0x01;
 const EXPECTED_RDATA_LEN: u16 = 0x04;
 
-#[cfg(feature = "dns")]
 pub(crate) struct Dns<'a> {
     seeds: Vec<&'a str>,
 }
 
 impl Dns<'_> {
-    #[cfg(feature = "dns")]
     pub fn new(network: Network) -> Self {
         let seeds = match network {
             Network::Bitcoin => MAINNET_SEEDS.to_vec(),
@@ -78,7 +76,6 @@ impl Dns<'_> {
         Self { seeds }
     }
 
-    #[cfg(feature = "dns")]
     pub async fn bootstrap(&self) -> Result<Vec<IpAddr>, DnsBootstrapError> {
         let mut ip_addrs: Vec<IpAddr> = vec![];
 

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -5,7 +5,6 @@ use bitcoin::{
 };
 
 pub(crate) mod counter;
-#[cfg(feature = "dns")]
 pub(crate) mod dns;
 #[allow(dead_code)]
 pub(crate) mod error;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -95,7 +95,6 @@ pub(crate) fn default_port_from_network(network: &Network) -> u16 {
     }
 }
 
-#[cfg(feature = "dns")]
 pub(crate) fn encode_qname(domain: &str) -> Vec<u8> {
     let mut qname = Vec::new();
     for label in domain.split('.') {


### PR DESCRIPTION
The original intention with the DNS feature was to enable the _ultra_ privacy-conscious users to circumvent DNS seeding, which would technically reveal in plaintext that the device is attempting to connect to bitcoin nodes. A feature in this case is overkill, as the binary size would be hardly effected if disabled, and the feature _should_ be used by the vast majority of users. I think a better approach in the future would be to disable DNS via the `NodeBuilder`. I am opting out of adding this configuration on `NodeBuilder` though, unless it is explicitly requested with some decent rationale.

Further still, if someone is actually doing traffic analysis, not all peers will connect over V2 transport at the moment anyway. 

Also to increase privacy in terms of the resolver handling our DNS queries, a custom resolver could be configured, which is something that should be easy enough to add to the `NodeBuilder`.

cc @nyonson  