### PR TITLE
Do not reset scripts and peers when adding them

### DIFF
--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -1,5 +1,3 @@
-#[cfg(not(feature = "filter-control"))]
-use std::collections::HashSet;
 use std::{path::PathBuf, time::Duration};
 
 use bitcoin::Network;
@@ -87,8 +85,8 @@ impl NodeBuilder {
     }
 
     /// Add preferred peers to try to connect to.
-    pub fn add_peers(mut self, whitelist: Vec<TrustedPeer>) -> Self {
-        self.config.white_list = whitelist;
+    pub fn add_peers(mut self, whitelist: impl IntoIterator<Item = TrustedPeer>) -> Self {
+        self.config.white_list.extend(whitelist);
         self
     }
 
@@ -100,8 +98,11 @@ impl NodeBuilder {
 
     /// Add Bitcoin scripts to monitor for. You may add more later with the [`Client`].
     #[cfg(not(feature = "filter-control"))]
-    pub fn add_scripts(mut self, addresses: HashSet<ScriptBuf>) -> Self {
-        self.config.addresses = addresses;
+    pub fn add_scripts(mut self, scripts: impl IntoIterator<Item = ScriptBuf>) -> Self {
+        let script_iter = scripts.into_iter();
+        for script in script_iter {
+            self.config.addresses.insert(script);
+        }
         self
     }
 


### PR DESCRIPTION
Currently the `add_peers` and `add_scripts` methods just set the collections internally. I came across an example in working with BDK where one might call `add_scripts` twice with two different sets of scripts, which would cause the second call to override the first. Of course the actual intention is to just add scripts to the collection. 

While I was at it, having explicit collections for each method argument doesn't make sense, as what collection we store scripts and peers in does not matter to the user. Instead I opted for the more general `IntoIterator`, which takes any collection or iterator of the type we are adding to the node. As a nice side effect this is non-breaking since `Vec` and `HashSet` implement `IntoIterator`.

cc @nyonson 