### PR TITLE
Introduce `PeerId` for stricter type meaning across the crate

### DIFF
--- a/src/core/channel_messages.rs
+++ b/src/core/channel_messages.rs
@@ -11,6 +11,8 @@ use bitcoin::{
 
 use crate::core::messages::RejectPayload;
 
+use super::PeerId;
+
 #[derive(Debug, Clone)]
 pub(crate) enum MainThreadMessage {
     GetAddr,
@@ -36,7 +38,7 @@ pub struct GetBlockConfig {
 }
 
 pub(crate) struct PeerThreadMessage {
-    pub nonce: u32,
+    pub nonce: PeerId,
     pub message: PeerMessage,
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,6 +7,7 @@
 //! To build a [`Node`](node::Node) and [`Client`](client::Client), please refer to the [`NodeBuilder`](builder::NodeBuilder), which allows for node
 //! configuration.
 
+use std::hash::Hash;
 use std::time::Duration;
 
 use tokio::time::Instant;
@@ -82,5 +83,26 @@ impl PeerTimeoutConfig {
             response_timeout,
             max_connection_time,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct PeerId(u32);
+
+impl PeerId {
+    pub(crate) fn increment(&mut self) {
+        self.0 = self.0.wrapping_add(1)
+    }
+}
+
+impl From<u32> for PeerId {
+    fn from(value: u32) -> Self {
+        PeerId(value)
+    }
+}
+
+impl std::fmt::Display for PeerId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Peer {}", self.0)
     }
 }

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -18,7 +18,7 @@ use crate::{
         channel_messages::{MainThreadMessage, PeerMessage, PeerThreadMessage},
         dialog::Dialog,
         messages::Warning,
-        PeerTimeoutConfig,
+        PeerId, PeerTimeoutConfig,
     },
     network::outbound_messages::V1OutboundMessage,
 };
@@ -42,7 +42,7 @@ const HANDSHAKE_TIMEOUT: u64 = 4;
 type MutexMessageGenerator = Mutex<Box<dyn MessageGenerator>>;
 
 pub(crate) struct Peer {
-    nonce: u32,
+    nonce: PeerId,
     main_thread_sender: Sender<PeerThreadMessage>,
     main_thread_recv: Receiver<MainThreadMessage>,
     network: Network,
@@ -54,7 +54,7 @@ pub(crate) struct Peer {
 
 impl Peer {
     pub fn new(
-        nonce: u32,
+        nonce: PeerId,
         network: Network,
         main_thread_sender: Sender<PeerThreadMessage>,
         main_thread_recv: Receiver<MainThreadMessage>,


### PR DESCRIPTION
There is a `u32` nonce that is used to identify peers when we open a connection to them and want to send a specific peer a message. Refactoring this to a wrapper type is hopefully easier to read, especially for folks not familiar with the library but would potentially want to submit a patch. 

You'll notice I used `wrapping_add` to prevent an overflow as well. Funny enough Bitcoin Core had the same problem of using plain old `u32` math that could be exploited.

cc @nyonson 