### PR TITLE
Introduce `HeightMonitor` to track chain height relative to peers

### DIFF
--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -18,6 +18,7 @@ use crate::core::PeerId;
 
 type Height = u32;
 
+#[derive(Debug)]
 pub(crate) struct HeightMonitor {
     map: HashMap<PeerId, Height>,
 }
@@ -30,7 +31,7 @@ impl HeightMonitor {
     }
 
     pub(crate) fn max(&self) -> Option<Height> {
-        self.map.iter().map(|(_, height)| *height).max()
+        self.map.values().copied().max()
     }
 
     pub(crate) fn retain(&mut self, peers: &[PeerId]) {

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -1,7 +1,6 @@
 //! Strucutres and checkpoints related to the blockchain.
 //!
 //! Notably, [`checkpoints`] contains known Bitcoin block hashes and heights with significant work, so Kyoto nodes do not have to sync from genesis.
-
 pub(crate) mod block_queue;
 #[allow(clippy::module_inception)]
 pub(crate) mod chain;
@@ -12,3 +11,71 @@ pub mod checkpoints;
 pub(crate) mod error;
 pub(crate) mod header_batch;
 pub(crate) mod header_chain;
+
+use std::collections::HashMap;
+
+use crate::core::PeerId;
+
+type Height = u32;
+
+pub(crate) struct HeightMonitor {
+    map: HashMap<PeerId, Height>,
+}
+
+impl HeightMonitor {
+    pub(crate) fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn max(&self) -> Option<Height> {
+        self.map.iter().map(|(_, height)| *height).max()
+    }
+
+    pub(crate) fn retain(&mut self, peers: &[PeerId]) {
+        self.map.retain(|peer_id, _| peers.contains(peer_id));
+    }
+
+    pub(crate) fn insert(&mut self, peer_id: PeerId, height: Height) {
+        self.map.insert(peer_id, height);
+    }
+
+    pub(crate) fn increment(&mut self, peer_id: PeerId) {
+        if let Some(height) = self.map.get_mut(&peer_id) {
+            *height = height.saturating_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_height_monitor() {
+        let peer_one = 1.into();
+        let peer_two = 2.into();
+        let peer_three = 3.into();
+
+        let mut height_monitor = HeightMonitor::new();
+        height_monitor.insert(peer_one, 10);
+        assert!(height_monitor.max().unwrap().eq(&10));
+        height_monitor.insert(peer_two, 11);
+        height_monitor.insert(peer_three, 12);
+        assert!(height_monitor.max().unwrap().eq(&12));
+        // this should remove peer three
+        height_monitor.retain(&[peer_one, peer_two]);
+        assert!(height_monitor.max().unwrap().eq(&11));
+        height_monitor.retain(&[]);
+        assert!(height_monitor.max().is_none());
+        height_monitor.insert(peer_one, 10);
+        assert!(height_monitor.max().unwrap().eq(&10));
+        height_monitor.insert(peer_two, 11);
+        // peer one is now at 11
+        height_monitor.increment(peer_one);
+        // peer one is now at 12
+        height_monitor.increment(peer_one);
+        assert!(height_monitor.max().unwrap().eq(&12));
+    }
+}


### PR DESCRIPTION
The previous design of determining if the chain is synced is a horrible artifact of moving from a proof-of-concept to an actual library. The `PeerMap` and `Chain` previously communicated via the `Node`, but there is no reason they can't share some common memory behind an `Arc` and `Mutex`.

Here I introduce a structure that keeps track of a peer and their height, and allows for the `Chain` to get the current maximum. I use the `tokio::sync::Mutex` to wrap this type, so the lock may be potentially held across `await` points if necessary. 

With this design, if a peer tries to grief the node by sending a ridiculous height, but cannot send the headers to reach that height, the node will disconnect from them and the height the malicious peer reported will no longer be used to determine if the node is synced.

cc @nyonson 