### PR TITLE
Remove unused `values` method

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -994,7 +994,12 @@ mod tests {
         assert!(extend_sync.is_ok());
         assert_eq!(
             vec![block_8, block_9, new_block_10, block_11],
-            chain.header_chain.values()
+            chain
+                .header_chain
+                .headers()
+                .values()
+                .copied()
+                .collect::<Vec<_>>()
         );
         assert_eq!(chain.fetch_header(10).await.unwrap().unwrap(), new_block_10);
         // A new peer sending us these headers should not do anything
@@ -1003,7 +1008,12 @@ mod tests {
         assert!(dup_sync.is_ok());
         assert_eq!(
             vec![block_8, block_9, new_block_10, block_11],
-            chain.header_chain.values()
+            chain
+                .header_chain
+                .headers()
+                .values()
+                .copied()
+                .collect::<Vec<_>>()
         );
     }
 
@@ -1026,12 +1036,25 @@ mod tests {
         let chain_sync = chain.sync_chain(batch_1).await;
         assert!(chain_sync.is_ok());
         assert_eq!(chain.height(), 3);
-        assert_eq!(chain.header_chain.values(), vec![block_1, block_2, block_3]);
+        assert_eq!(
+            chain
+                .header_chain
+                .headers()
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![block_1, block_2, block_3]
+        );
         let chain_sync = chain.sync_chain(batch_2).await;
         assert!(chain_sync.is_ok());
         assert_eq!(chain.height(), 4);
         assert_eq!(
-            chain.header_chain.values(),
+            chain
+                .header_chain
+                .headers()
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
             vec![block_1, block_2, new_block_3, block_4]
         );
     }
@@ -1057,7 +1080,15 @@ mod tests {
         let chain_sync = chain.sync_chain(batch_1).await;
         assert!(chain_sync.is_ok());
         assert_eq!(chain.height(), 2);
-        assert_eq!(chain.header_chain.values(), vec![block_1, block_2]);
+        assert_eq!(
+            chain
+                .header_chain
+                .headers()
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
+            vec![block_1, block_2]
+        );
         let chain_sync = chain.sync_chain(batch_2).await;
         assert!(chain_sync.is_err());
         assert_eq!(chain_sync.err().unwrap(), HeaderSyncError::LessWorkFork);
@@ -1071,7 +1102,12 @@ mod tests {
         assert_eq!(chain.height(), 3);
         assert_eq!(chain.fetch_header(3).await.unwrap().unwrap(), block_3);
         assert_eq!(
-            chain.header_chain.values(),
+            chain
+                .header_chain
+                .headers()
+                .values()
+                .copied()
+                .collect::<Vec<_>>(),
             vec![new_block_1, new_block_2, block_3]
         );
     }

--- a/src/chain/header_chain.rs
+++ b/src/chain/header_chain.rs
@@ -57,12 +57,6 @@ impl HeaderChain {
         &self.headers
     }
 
-    // All the headers of the chain
-    #[allow(dead_code)]
-    pub(crate) fn values(&self) -> Vec<Header> {
-        self.headers.values().copied().collect()
-    }
-
     // This header chain contains a block hash
     pub(crate) fn contains_hash(&self, blockhash: BlockHash) -> bool {
         self.headers
@@ -343,7 +337,7 @@ mod tests {
         assert_eq!(reorg.first().unwrap().header, block_10);
         assert_eq!(
             vec![block_8, block_9, new_block_10, block_11],
-            chain.values()
+            chain.headers().values().copied().collect::<Vec<_>>()
         );
         assert_eq!(chain.header_at_height(12), None);
         assert_eq!(chain.header_at_height(11), Some(&block_11));
@@ -372,7 +366,7 @@ mod tests {
         assert_eq!(reorged.len(), 2);
         assert_eq!(
             vec![block_1, block_2, new_block_3, new_block_4],
-            chain.values()
+            chain.headers().values().copied().collect::<Vec<_>>()
         );
         assert_eq!(chain.header_at_height(4), Some(&new_block_4));
         assert_eq!(chain.header_at_height(3), Some(&new_block_3));
@@ -403,12 +397,15 @@ mod tests {
             reorged.iter().map(|f| f.header).collect::<Vec<Header>>(),
             vec![block_1, block_2]
         );
-        assert_eq!(vec![new_block_1, new_block_2], chain.values());
+        assert_eq!(
+            vec![new_block_1, new_block_2],
+            chain.headers().values().copied().collect::<Vec<_>>()
+        );
         let no_org = chain.extend(&batch_2);
         assert_eq!(no_org.len(), 0);
         assert_eq!(
             vec![new_block_1, new_block_2, block_3, block_4],
-            chain.values()
+            chain.headers().values().copied().collect::<Vec<_>>()
         );
         assert_eq!(chain.header_at_height(3), Some(&block_3));
         let want = chain.height_of_hash(new_block_2.block_hash());


### PR DESCRIPTION
`HeaderChain::values` is not used anywhere but in tests. It doesn't serve a lot of purpose given that it implicitly calls `copied` and the `HeaderChain::headers` method exists. 