### PR TITLE
Move unit trait definitions into test module

### DIFF
--- a/src/db/error.rs
+++ b/src/db/error.rs
@@ -154,18 +154,3 @@ impl From<rusqlite::Error> for SqlHeaderStoreError {
         Self::SQL(value)
     }
 }
-
-/// Errors for the [`PeerStore`](crate) of unit type.
-#[derive(Debug)]
-pub enum UnitPeerStoreError {
-    /// There were no peers found.
-    NoPeers,
-}
-
-impl core::fmt::Display for UnitPeerStoreError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UnitPeerStoreError::NoPeers => write!(f, "no peers in unit database."),
-        }
-    }
-}


### PR DESCRIPTION
Users should not be able to pass the unit type as a `HeaderStore` or `PeerStore` implementation because this would almost certainly cause syncing problems. However these implementations might still be useful as mock types for tests. As a compromise, these traits are defined in the test context. Unfortunately the definitions do not carry into the `tests` folder, only unit tests. I think this is fine though, as the integration tests should test the actual use of the library.

Closes #291 

cc @nyonson 