### PR TITLE
Clean up the `HeaderStore` trait implementation

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -233,22 +233,12 @@ impl<H: HeaderStore> Chain<H> {
             .db
             .lock()
             .await
-            .write(self.header_chain.headers())
-            .await
-        {
-            self.dialog.send_warning(Warning::FailedPersistence {
-                warning: format!("Could not save headers to disk: {e}"),
-            });
-        }
-    }
-
-    // Write the chain to disk, overriding previous heights
-    pub(crate) async fn flush_over_height(&mut self, height: u32) {
-        if let Err(e) = self
-            .db
-            .lock()
-            .await
-            .write_over(self.header_chain.headers(), height)
+            .write(
+                self.header_chain
+                    .headers()
+                    .iter()
+                    .map(|(height, header)| (*height, header)),
+            )
             .await
         {
             self.dialog.send_warning(Warning::FailedPersistence {
@@ -436,7 +426,7 @@ impl<H: HeaderStore> Chain<H> {
                 self.filter_chain.remove(removed_hashes);
                 self.block_queue.remove(removed_hashes);
                 self.dialog.send_event(Event::BlocksDisconnected(reorged));
-                self.flush_over_height(stem).await;
+                self.flush_to_disk().await;
                 Ok(())
             } else {
                 self.dialog.send_warning(Warning::UnexpectedSyncError {


### PR DESCRIPTION
The `HeaderStore` trait implementation is contrived to put it mildly. There is no reason to have a `write` and `write_over`, other than my initial laziness when building the project. All the trait should know is there is a mapping between `u32` and `Header`, and the implementation should handle conflicts. In the SQL context, this means replacing headers at a height if there is indeed a conflict.

Sadly this needs to stay a draft until an MSRV decision is made for the next release. You'll noticed the `clone()` of the header chain in the first commit which isn't good. I would instead add something more like `take` to grab the headers, but in that method I would likely want to use `last_key_value` (1.66) on `BTreeMap` , seen in the second commit

cc @nyonson 