### PR TITLE
Improve `Filter` API

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -74,7 +74,7 @@ async fn main() {
                         Event::IndexedFilter(mut filter) => {
                             let height = filter.height();
                             tracing::info!("Checking filter: {height}");
-                            if filter.contains_any(&addresses) {
+                            if filter.contains_any(addresses.iter()) {
                                 let hash = *filter.block_hash();
                                 tracing::info!("Found script at {}!", hash);
                                 let indexed_block = requester.get_block(hash).await.unwrap();

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -727,7 +727,7 @@ impl<H: HeaderStore> Chain<H> {
         #[cfg(not(feature = "filter-control"))]
         if !self.block_queue.contains(&filter_message.block_hash)
             && filter
-                .contains_any(&self.scripts)
+                .contains_any(self.scripts.iter())
                 .map_err(CFilterSyncError::Filter)?
         {
             // Add to the block queue

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -7,8 +7,6 @@ pub(crate) mod cfheader_chain;
 pub(crate) mod error;
 pub(crate) mod filter_chain;
 
-use std::collections::HashSet;
-
 use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::{bip158::BlockFilter, BlockHash, FilterHash, ScriptBuf};
 
@@ -42,12 +40,12 @@ impl Filter {
         &self.block_hash
     }
 
-    pub fn contains_any(&mut self, scripts: &HashSet<ScriptBuf>) -> Result<bool, FilterError> {
+    pub fn contains_any<'a>(
+        &'a mut self,
+        scripts: impl Iterator<Item = &'a ScriptBuf>,
+    ) -> Result<bool, FilterError> {
         self.block_filter
-            .match_any(
-                &self.block_hash,
-                &mut scripts.iter().map(|script| script.to_bytes()),
-            )
+            .match_any(&self.block_hash, scripts.map(|script| script.to_bytes()))
             .map_err(|_| FilterError::IORead)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl IndexedFilter {
     }
 
     /// Does the filter contain a positive match for any of the provided scripts
-    pub fn contains_any(&mut self, scripts: &HashSet<ScriptBuf>) -> bool {
+    pub fn contains_any<'a>(&'a mut self, scripts: impl Iterator<Item = &'a ScriptBuf>) -> bool {
         self.filter
             .contains_any(scripts)
             .expect("vec reader is infallible")


### PR DESCRIPTION
There is a bit of trait hell going on within the `bip158` module. Something in the `BlockFilter` type is generic over `Read`, but the type itself concretely uses `Vec`. The `Read` implementation of  `Vec` doesn't do any I/O so the result is infallible. We can just add an `expect` instead of propagating this error everywhere.

ref: [Use of `Vec`](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/src/bip158.rs#L116) followed by [the trait hell](https://github.com/rust-bitcoin/rust-bitcoin/blob/master/bitcoin/src/bip158.rs#L280)

cc @nyonson  