### PR TITLE
Actually broadcast transactions

### DIFF
--- a/src/core/channel_messages.rs
+++ b/src/core/channel_messages.rs
@@ -6,7 +6,7 @@ use bitcoin::{
         message_network::VersionMessage,
         ServiceFlags,
     },
-    Block, BlockHash, FeeRate, Transaction,
+    Block, BlockHash, FeeRate, Transaction, Wtxid,
 };
 
 use crate::core::messages::RejectPayload;
@@ -17,6 +17,7 @@ use super::PeerId;
 pub(crate) enum MainThreadMessage {
     GetAddr,
     GetAddrV2,
+    WtxidRelay,
     GetHeaders(GetHeaderConfig),
     GetFilterHeaders(GetCFHeaders),
     GetFilters(GetCFilters),
@@ -58,6 +59,7 @@ pub(crate) enum PeerMessage {
     #[allow(dead_code)]
     Pong(u64),
     FeeFilter(FeeRate),
+    TxRequests(Vec<Wtxid>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -17,8 +17,8 @@ pub(crate) mod reader;
 pub(crate) mod tor;
 pub(crate) mod traits;
 
-pub const PROTOCOL_VERSION: u32 = 70013;
-pub const KYOTO_VERSION: &str = "0.6.0";
+pub const PROTOCOL_VERSION: u32 = 70016;
+pub const KYOTO_VERSION: &str = "0.8.0";
 pub const RUST_BITCOIN_VERSION: &str = "0.32.4";
 
 pub(crate) struct V1Header {

--- a/src/network/reader.rs
+++ b/src/network/reader.rs
@@ -96,7 +96,16 @@ impl Reader {
                     None
                 }
             }
-            NetworkMessage::GetData(_) => None,
+            NetworkMessage::GetData(inventory) => {
+                let mut requests = Vec::new();
+                for inv in inventory {
+                    match inv {
+                        Inventory::WTx(wtxid) => requests.push(wtxid),
+                        _ => continue,
+                    }
+                }
+                Some(PeerMessage::TxRequests(requests))
+            }
             NetworkMessage::NotFound(_) => None,
             NetworkMessage::GetBlocks(_) => None,
             NetworkMessage::GetHeaders(_) => None,
@@ -126,10 +135,10 @@ impl Reader {
             NetworkMessage::GetCFCheckpt(_) => None,
             NetworkMessage::CFCheckpt(_) => None,
             // Compact Block Relay is enabled with 70014
-            NetworkMessage::SendCmpct(_) => Some(PeerMessage::Disconnect),
-            NetworkMessage::CmpctBlock(_) => Some(PeerMessage::Disconnect),
-            NetworkMessage::GetBlockTxn(_) => Some(PeerMessage::Disconnect),
-            NetworkMessage::BlockTxn(_) => Some(PeerMessage::Disconnect),
+            NetworkMessage::SendCmpct(_) => None,
+            NetworkMessage::CmpctBlock(_) => None,
+            NetworkMessage::GetBlockTxn(_) => None,
+            NetworkMessage::BlockTxn(_) => None,
             NetworkMessage::Alert(_) => None,
             NetworkMessage::Reject(rejection) => {
                 let txid = Txid::from(rejection.hash);
@@ -149,7 +158,7 @@ impl Reader {
                 }
             }
             // 70016
-            NetworkMessage::WtxidRelay => Some(PeerMessage::Disconnect),
+            NetworkMessage::WtxidRelay => None,
             NetworkMessage::AddrV2(addresses) => {
                 if addresses.len() > MAX_ADDR {
                     return Some(PeerMessage::Disconnect);

--- a/src/network/traits.rs
+++ b/src/network/traits.rs
@@ -7,7 +7,7 @@ use bitcoin::{
         message::NetworkMessage,
         message_filter::{GetCFHeaders, GetCFilters},
     },
-    BlockHash, Transaction,
+    BlockHash, Transaction, Wtxid,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
@@ -34,6 +34,8 @@ pub(crate) trait MessageGenerator: Send + Sync {
 
     fn addrv2(&mut self) -> Result<Vec<u8>, PeerError>;
 
+    fn wtxid_relay(&mut self) -> Result<Vec<u8>, PeerError>;
+
     fn headers(
         &mut self,
         locator_hashes: Vec<BlockHash>,
@@ -48,7 +50,9 @@ pub(crate) trait MessageGenerator: Send + Sync {
 
     fn pong(&mut self, nonce: u64) -> Result<Vec<u8>, PeerError>;
 
-    fn transaction(&mut self, transaction: Transaction) -> Result<Vec<u8>, PeerError>;
+    fn announce_transaction(&mut self, wtxid: Wtxid) -> Result<Vec<u8>, PeerError>;
+
+    fn broadcast_transaction(&mut self, transaction: Transaction) -> Result<Vec<u8>, PeerError>;
 }
 
 // Responsible for parsing plaintext or encrypted messages off of the  wire.


### PR DESCRIPTION
To prevent spam, the peer to peer protocol actually requires a transaction be announced via an `inv` of the transaction hash, and if the remote node does not have that transaction, they respond with a `getdata`. Finally, the local sends a `tx` message with the full encoding. 

I am embarrassed to admit I had not researched this enough, and currently I don't believe previous versions would successfully broadcast transactions. I did test, however, this patch works on Signet by using a BDK wallet to generate the transaction, then checking mempool.space. A follow up test in the integration tests could be nice, but is non-trivial to implement.

Because this library doesn't have any users yet, and future wallets will almost certainly use SegWit for the discount, I decided to reject peers that have a protocol version lower than SegWit. This should be no issue as SegWit is adopted by virtually every client.

ref: [BIP 339](https://github.com/bitcoin/bips/blob/master/bip-0339.mediawiki) WTx inventory
