### PR TITLE
Allow for compiler optimizations and logging configuration

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -2,9 +2,9 @@
 //! many possible scripts to check. Enable the `filter-control` feature to check filters
 //! manually in your program.
 
-use kyoto::core::messages::{Event, Log};
+use kyoto::core::messages::Event;
 use kyoto::{chain::checkpoints::HeaderCheckpoint, core::builder::NodeBuilder, Client};
-use kyoto::{AddrV2, Address, BlockHash, Network, ServiceFlags, TrustedPeer};
+use kyoto::{AddrV2, Address, BlockHash, LogLevel, Network, ServiceFlags, TrustedPeer};
 use std::collections::HashSet;
 use std::{net::Ipv4Addr, str::FromStr};
 
@@ -45,6 +45,8 @@ async fn main() {
         .anchor_checkpoint(checkpoint)
         // The number of connections we would like to maintain
         .num_required_peers(1)
+        // Omit informational messages
+        .log_level(LogLevel::Warning)
         // Create the node and client
         .build_node()
         .unwrap();
@@ -63,9 +65,7 @@ async fn main() {
         tokio::select! {
             log = log_rx.recv() => {
                 if let Some(log) = log {
-                    if let Log::Dialog(log) = log {
-                        tracing::info!("{log}")
-                    }
+                    tracing::info!("{log}");
                 }
             }
             event = event_rx.recv() => {

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -87,7 +87,7 @@ async fn main() {
             log = log_rx.recv() => {
                 if let Some(log) = log {
                     match log {
-                        Log::Dialog(d)=> tracing::info!("{d}"),
+                        Log::Debug(d)=> tracing::info!("{d}"),
                         Log::StateChange(node_state) => tracing::info!("{node_state}"),
                         Log::ConnectionsMet => tracing::info!("All required connections met"),
                         _ => (),

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -79,7 +79,7 @@ async fn main() {
             log = log_rx.recv() => {
                 if let Some(log) = log {
                     match log {
-                        Log::Dialog(d)=> tracing::info!("{d}"),
+                        Log::Debug(d)=> tracing::info!("{d}"),
                         Log::StateChange(node_state) => tracing::info!("{node_state}"),
                         Log::ConnectionsMet => tracing::info!("All required connections met"),
                         _ => (),

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -532,8 +532,7 @@ impl<H: HeaderStore> Chain<H> {
                 None => {
                     crate::log!(
                         self.dialog,
-                        "Unable to audit difficulty.
-                        /This is likely due to no history present in the header store"
+                        "Unable to audit difficulty. This is likely due to no history present in the header store"
                     );
                 }
             },

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -143,8 +143,8 @@ impl NodeBuilder {
         self
     }
 
-    /// Set the [`LogLevel`](crate). Omitting log messages may improve performance.
-    pub fn set_log_level(mut self, log_level: LogLevel) -> Self {
+    /// Set the [`LogLevel`](crate::LogLevel). Omitting log messages may improve performance.
+    pub fn log_level(mut self, log_level: LogLevel) -> Self {
         self.config.log_level = log_level;
         self
     }

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -15,7 +15,7 @@ use crate::{
     chain::checkpoints::HeaderCheckpoint,
     db::traits::{HeaderStore, PeerStore},
 };
-use crate::{ConnectionType, PeerStoreSizeConfig, TrustedPeer};
+use crate::{ConnectionType, LogLevel, PeerStoreSizeConfig, TrustedPeer};
 
 #[cfg(feature = "database")]
 /// The default node returned from the [`NodeBuilder`](crate::core).
@@ -140,6 +140,12 @@ impl NodeBuilder {
     /// If none is provided, the _most recent_ checkpoint will be used.
     pub fn anchor_checkpoint(mut self, checkpoint: impl Into<HeaderCheckpoint>) -> Self {
         self.config.header_checkpoint = Some(checkpoint.into());
+        self
+    }
+
+    /// Set the [`LogLevel`](crate). Omitting log messages may improve performance.
+    pub fn set_log_level(mut self, log_level: LogLevel) -> Self {
+        self.config.log_level = log_level;
         self
     }
 

--- a/src/core/client.rs
+++ b/src/core/client.rs
@@ -364,15 +364,13 @@ mod tests {
             warn_rx: _,
             event_rx: _,
         } = Client::new(log_rx, warn_rx, event_rx, ctx);
-        let send_res = log_tx
-            .send(Log::Dialog("An important message".into()))
-            .await;
+        let send_res = log_tx.send(Log::Debug("An important message".into())).await;
         assert!(send_res.is_ok());
         let message = log_rx.recv().await;
         assert!(message.is_some());
         tokio::task::spawn(async move {
             log_tx
-                .send(Log::Dialog("Another important message".into()))
+                .send(Log::Debug("Another important message".into()))
                 .await
         });
         assert!(send_res.is_ok());

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, path::PathBuf, time::Duration};
 use bitcoin::ScriptBuf;
 
 use crate::{
-    chain::checkpoints::HeaderCheckpoint, network::dns::DnsResolver, ConnectionType,
+    chain::checkpoints::HeaderCheckpoint, network::dns::DnsResolver, ConnectionType, LogLevel,
     PeerStoreSizeConfig, TrustedPeer,
 };
 
@@ -26,6 +26,7 @@ pub(crate) struct NodeConfig {
     pub response_timeout: Duration,
     pub max_connection_time: Duration,
     pub filter_sync_policy: FilterSyncPolicy,
+    pub log_level: LogLevel,
 }
 
 impl Default for NodeConfig {
@@ -42,6 +43,7 @@ impl Default for NodeConfig {
             response_timeout: Duration::from_secs(TIMEOUT_SECS),
             max_connection_time: Duration::from_secs(TWO_HOUR),
             filter_sync_policy: Default::default(),
+            log_level: Default::default(),
         }
     }
 }

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -45,11 +45,13 @@ impl Dialog {
                 best_height,
             )))
             .await;
-        let message = format!(
-            "Headers ({}/{}) Compact Filter Headers ({}/{}) Filters ({}/{})",
-            num_headers, best_height, num_cf_headers, best_height, num_filters, best_height
-        );
-        let _ = self.log_tx.send(Log::Dialog(message)).await;
+        if matches!(self.log_level, LogLevel::Debug) {
+            let message = format!(
+                "Headers ({}/{}) Compact Filter Headers ({}/{}) Filters ({}/{})",
+                num_headers, best_height, num_cf_headers, best_height, num_filters, best_height
+            );
+            let _ = self.log_tx.send(Log::Dialog(message)).await;
+        }
     }
 
     pub(crate) fn send_warning(&self, warning: Warning) {

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -27,7 +27,7 @@ impl Dialog {
     }
 
     pub(crate) async fn send_dialog(&self, dialog: impl Into<String>) {
-        let _ = self.log_tx.send(Log::Dialog(dialog.into())).await;
+        let _ = self.log_tx.send(Log::Debug(dialog.into())).await;
     }
 
     pub(crate) async fn chain_update(
@@ -50,7 +50,7 @@ impl Dialog {
                 "Headers ({}/{}) Compact Filter Headers ({}/{}) Filters ({}/{})",
                 num_headers, best_height, num_cf_headers, best_height, num_filters, best_height
             );
-            let _ = self.log_tx.send(Log::Dialog(message)).await;
+            let _ = self.log_tx.send(Log::Debug(message)).await;
         }
     }
 

--- a/src/core/dialog.rs
+++ b/src/core/dialog.rs
@@ -1,9 +1,11 @@
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 
 use super::messages::{Event, Log, Progress, Warning};
+use crate::LogLevel;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Dialog {
+    pub(crate) log_level: LogLevel,
     log_tx: Sender<Log>,
     warn_tx: UnboundedSender<Warning>,
     event_tx: UnboundedSender<Event>,
@@ -11,11 +13,13 @@ pub(crate) struct Dialog {
 
 impl Dialog {
     pub(crate) fn new(
+        log_level: LogLevel,
         log_tx: Sender<Log>,
         warn_tx: UnboundedSender<Warning>,
         event_tx: UnboundedSender<Event>,
     ) -> Self {
         Self {
+            log_level,
             log_tx,
             warn_tx,
             event_tx,

--- a/src/core/messages.rs
+++ b/src/core/messages.rs
@@ -20,7 +20,7 @@ use super::{
 #[derive(Debug, Clone)]
 pub enum Log {
     /// Human readable dialog of what the node is currently doing.
-    Dialog(String),
+    Debug(String),
     /// The current state of the node in the syncing process.
     StateChange(NodeState),
     /// The node is connected to all required peers.
@@ -36,7 +36,7 @@ pub enum Log {
 impl core::fmt::Display for Log {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Log::Dialog(d) => write!(f, "{}", d),
+            Log::Debug(d) => write!(f, "{}", d),
             Log::StateChange(s) => write!(f, "{}", s),
             Log::TxSent(txid) => write!(f, "Transaction sent: {}", txid),
             Log::ConnectionsMet => write!(f, "Required connections met"),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,7 +20,6 @@ pub(crate) mod channel_messages;
 pub mod client;
 /// Node configuration options.
 pub(crate) mod config;
-#[macro_use]
 pub(crate) mod dialog;
 /// Errors associated with a node.
 pub mod error;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod channel_messages;
 pub mod client;
 /// Node configuration options.
 pub(crate) mod config;
+#[macro_use]
 pub(crate) mod dialog;
 /// Errors associated with a node.
 pub mod error;

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -95,6 +95,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             response_timeout,
             max_connection_time,
             filter_sync_policy,
+            log_level,
         } = config;
         let timeout_config = PeerTimeoutConfig::new(response_timeout, max_connection_time);
         // Set up a communication channel between the node and client
@@ -104,7 +105,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
         let client = Client::new(log_rx, warn_rx, event_rx, ctx);
         // A structured way to talk to the client
-        let dialog = Dialog::new(log_tx, warn_tx, event_tx);
+        let dialog = Dialog::new(log_level, log_tx, warn_tx, event_tx);
         // We always assume we are behind
         let state = Arc::new(RwLock::new(NodeState::Behind));
         // Configure the peer manager

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -163,13 +163,14 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     ///
     /// A node will cease running if a fatal error is encountered with either the [`PeerStore`] or [`HeaderStore`].
     pub async fn run(&self) -> Result<(), NodeError<H::Error, P::Error>> {
-        self.dialog.send_dialog("Starting node").await;
-        self.dialog
-            .send_dialog(format!(
+        crate::log!(self.dialog, "Starting node");
+        crate::log!(
+            self.dialog,
+            format!(
                 "Configured connection requirement: {} peers",
                 self.required_peers
-            ))
-            .await;
+            )
+        );
         self.fetch_headers().await?;
         let mut last_block = LastBlockMonitor::new();
         let mut peer_recv = self.peer_recv.lock().await;
@@ -198,14 +199,12 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                     }
                                     let response = self.handle_version(peer_thread.nonce, version).await?;
                                     self.send_message(peer_thread.nonce, response).await;
-                                    self.dialog.send_dialog(format!("[{}]: version", peer_thread.nonce))
-                                        .await;
+                                    crate::log!(self.dialog, format!("[{}]: version", peer_thread.nonce));
                                 }
                                 PeerMessage::Addr(addresses) => self.handle_new_addrs(addresses).await,
                                 PeerMessage::Headers(headers) => {
                                     last_block.reset();
-                                    self.dialog.send_dialog(format!("[{}]: headers", peer_thread.nonce))
-                                        .await;
+                                    crate::log!(self.dialog, format!("[{}]: headers", peer_thread.nonce));
                                     match self.handle_headers(peer_thread.nonce, headers).await {
                                         Some(response) => {
                                             self.send_message(peer_thread.nonce, response).await;
@@ -214,7 +213,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                     }
                                 }
                                 PeerMessage::FilterHeaders(cf_headers) => {
-                                    self.dialog.send_dialog(format!("[{}]: filter headers", peer_thread.nonce)).await;
+                                    crate::log!(self.dialog, format!("[{}]: filter headers", peer_thread.nonce));
                                     match self.handle_cf_headers(peer_thread.nonce, cf_headers).await {
                                         Some(response) => {
                                             self.broadcast(response).await;
@@ -237,8 +236,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                                     None => continue,
                                 },
                                 PeerMessage::NewBlocks(blocks) => {
-                                    self.dialog.send_dialog(format!("[{}]: inv", peer_thread.nonce))
-                                        .await;
+                                    crate::log!(self.dialog, format!("[{}]: inv", peer_thread.nonce));
                                     match self.handle_inventory_blocks(peer_thread.nonce, blocks).await {
                                         Some(response) => {
                                             self.broadcast(response).await;
@@ -367,9 +365,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
     // If there are blocks in the queue, we should request them of a random peer
     async fn get_blocks(&self) {
         if let Some(block_request) = self.pop_block_queue().await {
-            self.dialog
-                .send_dialog("Sending block request to a random peer")
-                .await;
+            crate::log!(self.dialog, "Sending block request to random peer");
             self.send_random(block_request).await;
         }
     }
@@ -386,20 +382,16 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
                 let txid = transaction.tx.compute_txid();
                 let did_broadcast = match transaction.broadcast_policy {
                     TxBroadcastPolicy::AllPeers => {
-                        self.dialog
-                            .send_dialog(format!(
-                                "Sending transaction to {} connected peers",
-                                peer_map.live()
-                            ))
-                            .await;
+                        crate::log!(
+                            self.dialog,
+                            format!("Sending transaction to {} connected peers", peer_map.live())
+                        );
                         peer_map
                             .broadcast(MainThreadMessage::BroadcastTx(transaction.tx))
                             .await
                     }
                     TxBroadcastPolicy::RandomPeer => {
-                        self.dialog
-                            .send_dialog("Sending transaction to a random peer")
-                            .await;
+                        crate::log!(self.dialog, "Sending transaction to a random peer");
                         peer_map
                             .send_random(MainThreadMessage::BroadcastTx(transaction.tx))
                             .await
@@ -465,9 +457,10 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             NodeState::TransactionsSynced => {
                 if last_block.stale() {
                     self.dialog.send_warning(Warning::PotentialStaleTip);
-                    self.dialog
-                        .send_dialog("Disconnecting from remote nodes to find new connections")
-                        .await;
+                    crate::log!(
+                        self.dialog,
+                        "Disconnecting from remote nodes to find new connections"
+                    );
                     self.broadcast(MainThreadMessage::Disconnect).await;
                     last_block.reset();
                 }
@@ -540,7 +533,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             .await;
         // Now we may request peers if required
         if needs_peers {
-            self.dialog.send_dialog("Requesting new addresses").await;
+            crate::log!(self.dialog, "Requesting new addresses");
             peer_map
                 .send_message(nonce, MainThreadMessage::GetAddr)
                 .await;
@@ -560,12 +553,10 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
 
     // Handle new addresses gossiped over the p2p network
     async fn handle_new_addrs(&self, new_peers: Vec<CombinedAddr>) {
-        self.dialog
-            .send_dialog(format!(
-                "Adding {} new peers to the peer database",
-                new_peers.len()
-            ))
-            .await;
+        crate::log!(
+            self.dialog,
+            format!("Adding {} new peers to the peer database", new_peers.len())
+        );
         let mut peer_map = self.peer_map.lock().await;
         peer_map.add_gossiped_peers(new_peers).await;
     }
@@ -680,9 +671,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             let next_block_hash = chain.next_block();
             return match next_block_hash {
                 Some(block_hash) => {
-                    self.dialog
-                        .send_dialog(format!("Next block in queue: {}", block_hash))
-                        .await;
+                    crate::log!(self.dialog, format!("Next block in queue: {}", block_hash));
                     Some(MainThreadMessage::GetBlock(GetBlockConfig {
                         locator: block_hash,
                     }))
@@ -705,9 +694,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         for block in blocks.iter() {
             peer_map.increment_height(nonce).await;
             if !chain.contains_hash(*block) {
-                self.dialog
-                    .send_dialog(format!("New block: {}", block))
-                    .await;
+                crate::log!(self.dialog, format!("New block: {}", block));
             }
         }
         match *state {
@@ -775,9 +762,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
 
     // When the application starts, fetch any headers we know about from the database.
     async fn fetch_headers(&self) -> Result<(), NodeError<H::Error, P::Error>> {
-        self.dialog
-            .send_dialog("Attempting to load headers from the database")
-            .await;
+        crate::log!(self.dialog, "Attempting to load headers from the database");
         let mut chain = self.chain.lock().await;
         chain
             .load_headers()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -430,7 +430,8 @@ pub enum PeerStoreSizeConfig {
 /// Select the category of messages for the node to emit.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum LogLevel {
-    /// Send `Log::Dialog` messages.
+    /// Send `Log::Dialog` messages. These messages are intended for debugging or troubleshooting
+    /// node operation.
     #[default]
     Debug,
     /// Omit `Log::Dialog` messages, including their memory allocations. Ideal for a production

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,3 +437,14 @@ pub enum LogLevel {
     /// application that uses minimal logging.
     Warning,
 }
+
+macro_rules! log {
+    ($dialog:expr, $expr:expr) => {
+        match $dialog.log_level {
+            crate::LogLevel::Debug => $dialog.send_dialog($expr).await,
+            crate::LogLevel::Warning => (),
+        }
+    };
+}
+
+pub(crate) use log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!             log = log_rx.recv() => {
 //!                 if let Some(log) = log {
 //!                     match log {
-//!                         Log::Dialog(d) => tracing::info!("{d}"),
+//!                         Log::Debug(d) => tracing::info!("{d}"),
 //!                         _ => (),
 //!                     }
 //!                 }
@@ -430,11 +430,11 @@ pub enum PeerStoreSizeConfig {
 /// Select the category of messages for the node to emit.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum LogLevel {
-    /// Send `Log::Dialog` messages. These messages are intended for debugging or troubleshooting
+    /// Send `Log::Debug` messages. These messages are intended for debugging or troubleshooting
     /// node operation.
     #[default]
     Debug,
-    /// Omit `Log::Dialog` messages, including their memory allocations. Ideal for a production
+    /// Omit `Log::Debug` messages, including their memory allocations. Ideal for a production
     /// application that uses minimal logging.
     Warning,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,3 +426,14 @@ pub enum PeerStoreSizeConfig {
     /// has at least this amount of peers.
     Limit(u32),
 }
+
+/// Select the category of messages for the node to emit.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    /// Send `Log::Dialog` messages.
+    #[default]
+    Debug,
+    /// Omit `Log::Dialog` messages, including their memory allocations. Ideal for a production
+    /// application that uses minimal logging.
+    Warning,
+}

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -611,7 +611,7 @@ async fn halting_download_works() {
     // Ensure SQL is able to catch the fork by loading in headers from the database
     while let Some(message) = log.recv().await {
         match message {
-            Log::Dialog(d) => println!("{d}"),
+            Log::Debug(d) => println!("{d}"),
             Log::StateChange(node_state) => {
                 if let NodeState::FilterHeadersSynced = node_state {
                     println!("Sleeping for one second...");


### PR DESCRIPTION
Closes #298 

The `format!` macro requires a heap allocation, and the `&str` references are converted to `String` when sent as a `Log::Dialog` message. Because some applications might be more memory hungry than others, there should be a way to stop the node from allocating these `String` entirely. I thought about having this as a crate feature, but the language bindings used by BDK would not be able to make use of this performance gain, since they ship a binary. I think I strike the best of both worlds here and use a runtime variable that can still be optimized away by the compiler.

To prove this works, I made a simple example. Check out this in the [Rust playground](https://play.rust-lang.org/?version=stable&mode=release&edition=2021) and select "ASM" using the three dots on the top left.

```rust
macro_rules! conditional_run {
    ($foo:expr, $expr:expr) => {
        match $foo.condition {
            Condition::Run => { $foo.do_foo($expr); }
            Condition::Skip => {} 
        }
    };
}

enum Condition {
    Run,
    Skip,
}

struct Foo {
    condition: Condition
}

impl Foo {
    fn do_foo(&self, message: String) {
        println!("{message}");
    }
}

fn main() {
    let condition = Condition::Skip;
    let foo = Foo { condition };
    conditional_run!(foo, format!("Allocated String!")); 
    println!("No allocation occurred!");
}
```

The compiler can remove the branching and either completely ignore the expression, thus not allocating the `String`, or execute the expression and send a debug message. Only downside to this approach is the `Log::Dialog` is still a member of `Log` even though we don't need it. Not sure how to get rid of it without introducing compile-time options though.

