### PR TITLE
Use `Arc` to clone `Dialog`

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -59,7 +59,7 @@ pub(crate) struct Chain<H: HeaderStore> {
     heights: Arc<Mutex<HeightMonitor>>,
     scripts: HashSet<ScriptBuf>,
     block_queue: BlockQueue,
-    dialog: Dialog,
+    dialog: Arc<Dialog>,
 }
 
 #[allow(dead_code)]
@@ -70,7 +70,7 @@ impl<H: HeaderStore> Chain<H> {
         scripts: HashSet<ScriptBuf>,
         anchor: HeaderCheckpoint,
         checkpoints: HeaderCheckpoints,
-        dialog: Dialog,
+        dialog: Arc<Dialog>,
         height_monitor: Arc<Mutex<HeightMonitor>>,
         db: H,
         quorum_required: usize,
@@ -926,7 +926,12 @@ mod tests {
             HashSet::new(),
             anchor,
             checkpoints,
-            Dialog::new(crate::LogLevel::Debug, log_tx, warn_tx, event_tx),
+            Arc::new(Dialog::new(
+                crate::LogLevel::Debug,
+                log_tx,
+                warn_tx,
+                event_tx,
+            )),
             height_monitor,
             (),
             peers,

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -70,7 +70,7 @@ pub struct Node<H: HeaderStore, P: PeerStore> {
     peer_map: Arc<Mutex<PeerMap<P>>>,
     tx_broadcaster: Arc<Mutex<Broadcaster>>,
     required_peers: PeerRequirement,
-    dialog: Dialog,
+    dialog: Arc<Dialog>,
     client_recv: Arc<Mutex<Receiver<ClientMessage>>>,
     peer_recv: Arc<Mutex<Receiver<PeerThreadMessage>>>,
     filter_sync_policy: Arc<RwLock<FilterSyncPolicy>>,
@@ -105,7 +105,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
         let client = Client::new(log_rx, warn_rx, event_rx, ctx);
         // A structured way to talk to the client
-        let dialog = Dialog::new(log_level, log_tx, warn_tx, event_tx);
+        let dialog = Arc::new(Dialog::new(log_level, log_tx, warn_tx, event_tx));
         // We always assume we are behind
         let state = Arc::new(RwLock::new(NodeState::Behind));
         // Configure the peer manager
@@ -116,7 +116,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             network,
             peer_store,
             white_list,
-            dialog.clone(),
+            Arc::clone(&dialog),
             connection_type,
             target_peer_size,
             timeout_config,
@@ -135,7 +135,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
             addresses,
             checkpoint,
             checkpoints,
-            dialog.clone(),
+            Arc::clone(&dialog),
             height_monitor,
             header_store,
             required_peers.into(),

--- a/src/core/peer_map.rs
+++ b/src/core/peer_map.rs
@@ -68,7 +68,7 @@ pub(crate) struct PeerMap<P: PeerStore> {
     db: Arc<Mutex<P>>,
     connector: Arc<Mutex<dyn NetworkConnector + Send + Sync>>,
     whitelist: Whitelist,
-    dialog: Dialog,
+    dialog: Arc<Dialog>,
     target_db_size: PeerStoreSizeConfig,
     net_groups: HashSet<String>,
     timeout_config: PeerTimeoutConfig,
@@ -83,7 +83,7 @@ impl<P: PeerStore> PeerMap<P> {
         network: Network,
         db: P,
         whitelist: Whitelist,
-        dialog: Dialog,
+        dialog: Arc<Dialog>,
         connection_type: ConnectionType,
         target_db_size: PeerStoreSizeConfig,
         timeout_config: PeerTimeoutConfig,
@@ -177,7 +177,7 @@ impl<P: PeerStore> PeerMap<P> {
             self.mtx.clone(),
             prx,
             loaded_peer.services,
-            self.dialog.clone(),
+            Arc::clone(&self.dialog),
             self.timeout_config,
         );
         let mut connector = self.connector.lock().await;

--- a/src/network/peer.rs
+++ b/src/network/peer.rs
@@ -1,5 +1,5 @@
 extern crate tokio;
-use std::{ops::DerefMut, time::Duration};
+use std::{ops::DerefMut, sync::Arc, time::Duration};
 
 use bip324::{AsyncProtocol, PacketReader, PacketWriter, Role};
 use bitcoin::{p2p::ServiceFlags, Network};
@@ -48,7 +48,7 @@ pub(crate) struct Peer {
     network: Network,
     message_counter: MessageCounter,
     services: ServiceFlags,
-    dialog: Dialog,
+    dialog: Arc<Dialog>,
     timeout_config: PeerTimeoutConfig,
 }
 
@@ -59,7 +59,7 @@ impl Peer {
         main_thread_sender: Sender<PeerThreadMessage>,
         main_thread_recv: Receiver<MainThreadMessage>,
         services: ServiceFlags,
-        dialog: Dialog,
+        dialog: Arc<Dialog>,
         timeout_config: PeerTimeoutConfig,
     ) -> Self {
         let message_counter = MessageCounter::new(timeout_config.response_timeout);


### PR DESCRIPTION
I think the proper "rustonic" thing to do here is use a reference counted pointer to anything that needs a `Dialog` to communicate with the client. I change all instances of `Dialog` with `Arc<Dialog>` and explicitly clone using `Arc::clone` to indicate the clone is cheap. Also verified that the recent log changes still omit unnecessary allocations.