### PR TITLE
Use declarative naming for methods in builder

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -44,11 +44,11 @@ async fn main() {
         // Only scan blocks strictly after an anchor checkpoint
         .anchor_checkpoint(checkpoint)
         // The number of connections we would like to maintain
-        .num_required_peers(1)
+        .required_peers(1)
         // Omit informational messages
         .log_level(LogLevel::Warning)
         // Create the node and client
-        .build_node()
+        .build()
         .unwrap();
 
     tokio::task::spawn(async move { node.run().await });

--- a/example/rescan.rs
+++ b/example/rescan.rs
@@ -35,8 +35,8 @@ async fn main() {
             NETWORK,
         ))
         // The number of connections we would like to maintain
-        .num_required_peers(1)
-        .build_node()
+        .required_peers(1)
+        .build()
         .unwrap();
     // Run the node and wait for the sync message;
     tokio::task::spawn(async move { node.run().await });

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -45,9 +45,9 @@ async fn main() {
         // Only scan blocks strictly after an anchor checkpoint
         .anchor_checkpoint(checkpoint)
         // The number of connections we would like to maintain
-        .num_required_peers(2)
+        .required_peers(2)
         // Create the node and client
-        .build_node()
+        .build()
         .unwrap();
     // Run the node on a separate task
     tokio::task::spawn(async move { node.run().await });

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -38,9 +38,9 @@ async fn main() {
         // Store a limited number of peers
         .peer_db_size(PeerStoreSizeConfig::Limit(256))
         // The number of connections we would like to maintain
-        .num_required_peers(1)
+        .required_peers(1)
         // Create the node and client
-        .build_node()
+        .build()
         .unwrap();
 
     // Run the node on a new task

--- a/example/tor.rs
+++ b/example/tor.rs
@@ -49,13 +49,13 @@ async fn main() {
         // Only scan blocks strictly after an anchor checkpoint
         .anchor_checkpoint(anchor)
         // The number of connections we would like to maintain
-        .num_required_peers(2)
+        .required_peers(2)
         // We only maintain a list of 256 peers in memory
         .peer_db_size(PeerStoreSizeConfig::Limit(256))
         // Connect to peers over Tor
-        .set_connection_type(ConnectionType::Tor(tor))
+        .connection_type(ConnectionType::Tor(tor))
         // Build without the default databases
-        .build_node()
+        .build()
         .unwrap();
     // Run the node
     tokio::task::spawn(async move { node.run().await });

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -39,7 +39,7 @@ const MAX_PEERS: u8 = 15;
 /// let builder = NodeBuilder::new(Network::Regtest);
 /// let (node, client) = builder
 ///     .add_peers(vec![host.into()])
-///     .build_node()
+///     .build()
 ///     .unwrap();
 /// ```
 ///
@@ -68,8 +68,8 @@ const MAX_PEERS: u8 = 15;
 ///     // Only scan blocks strictly after an anchor checkpoint
 ///     .anchor_checkpoint(checkpoint)
 ///     // The number of connections we would like to maintain
-///     .num_required_peers(2)
-///     .build_node()
+///     .required_peers(2)
+///     .build()
 ///     .unwrap();
 /// ```
 pub struct NodeBuilder {
@@ -110,7 +110,7 @@ impl NodeBuilder {
 
     /// Add a path to the directory where data should be stored. If none is provided, the current
     /// working directory will be used.
-    pub fn add_data_dir(mut self, path: impl Into<PathBuf>) -> Self {
+    pub fn data_dir(mut self, path: impl Into<PathBuf>) -> Self {
         self.config.data_path = Some(path.into());
         self
     }
@@ -119,7 +119,7 @@ impl NodeBuilder {
     /// Adding more connections increases the node's anonymity, but requires waiting for more responses,
     /// higher bandwidth, and higher memory requirements. If none is provided, a single connection will be maintained.
     /// The number of connections will be clamped to a range of 1 to 15.
-    pub fn num_required_peers(mut self, num_peers: u8) -> Self {
+    pub fn required_peers(mut self, num_peers: u8) -> Self {
         self.config.required_peers = num_peers.clamp(MIN_PEERS, MAX_PEERS);
         self
     }
@@ -150,7 +150,7 @@ impl NodeBuilder {
     }
 
     /// Set the desired communication channel. Either directly over TCP or over the Tor network.
-    pub fn set_connection_type(mut self, connection_type: ConnectionType) -> Self {
+    pub fn connection_type(mut self, connection_type: ConnectionType) -> Self {
         self.config.connection_type = connection_type;
         self
     }
@@ -164,7 +164,7 @@ impl NodeBuilder {
     /// nodes may be slower to respond while processing blocks and transactions.
     ///
     /// If none is provided, a timeout of 5 seconds will be used.
-    pub fn set_response_timeout(mut self, response_timeout: Duration) -> Self {
+    pub fn response_timeout(mut self, response_timeout: Duration) -> Self {
         self.config.response_timeout = response_timeout;
         self
     }
@@ -176,10 +176,10 @@ impl NodeBuilder {
     ///
     /// This value is configurable as some developers may be satisfied with a peer
     /// as long as the peer responds promptly. Other implementations may value finding
-    /// new a reliable peers faster, so the maximum connection time may be shorter.
+    /// new and reliable peers faster, so the maximum connection time may be shorter.
     ///
     /// If none is provided, a maximum connection time of two hours will be used.
-    pub fn set_maximum_connection_time(mut self, max_connection_time: Duration) -> Self {
+    pub fn maximum_connection_time(mut self, max_connection_time: Duration) -> Self {
         self.config.max_connection_time = max_connection_time;
         self
     }
@@ -207,7 +207,7 @@ impl NodeBuilder {
     ///
     /// Building a node and client will error if a database connection is denied or cannot be found.
     #[cfg(feature = "database")]
-    pub fn build_node(&mut self) -> Result<(NodeDefault, Client), SqlInitializationError> {
+    pub fn build(&mut self) -> Result<(NodeDefault, Client), SqlInitializationError> {
         let peer_store = SqlitePeerDb::new(self.network, self.config.data_path.clone())?;
         let header_store = SqliteHeaderDb::new(self.network, self.config.data_path.clone())?;
         Ok(Node::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,14 @@
 //!     // Create a new node builder
 //!     let builder = NodeBuilder::new(Network::Signet);
 //!     // Add node preferences and build the node/client
-//!     let (mut node, client) = builder
+//!     let (node, client) = builder
 //!         // The Bitcoin scripts to monitor
 //!         .add_scripts(addresses)
 //!         // Only scan blocks strictly after an anchor checkpoint
 //!         .anchor_checkpoint(checkpoint)
 //!         // The number of connections we would like to maintain
-//!         .num_required_peers(2)
-//!         .build_node()
+//!         .required_peers(2)
+//!         .build()
 //!         .unwrap();
 //!     // Run the node and wait for the sync message;
 //!     tokio::task::spawn(async move { node.run().await });

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -52,8 +52,8 @@ fn new_node_sql(
     let (node, client) = builder
         .add_peer(host)
         .add_scripts(addrs)
-        .add_data_dir(tempdir_path)
-        .build_node()
+        .data_dir(tempdir_path)
+        .build()
         .unwrap();
     (node, client)
 }
@@ -71,9 +71,9 @@ fn new_node_anchor_sql(
     let (node, client) = builder
         .add_peer(trusted)
         .add_scripts(addrs)
-        .add_data_dir(tempdir_path)
+        .data_dir(tempdir_path)
         .anchor_checkpoint(checkpoint)
-        .build_node()
+        .build()
         .unwrap();
     (node, client)
 }
@@ -596,9 +596,9 @@ async fn halting_download_works() {
     let (node, client) = builder
         .add_peers(vec![host.into()])
         .add_scripts(scripts)
-        .add_data_dir(tempdir)
+        .data_dir(tempdir)
         .halt_filter_download()
-        .build_node()
+        .build()
         .unwrap();
 
     tokio::task::spawn(async move { node.run().await });
@@ -649,8 +649,8 @@ async fn signet_syncs() {
     let (node, client) = builder
         .add_peer(host)
         .add_scripts(set)
-        .add_data_dir(tempdir)
-        .build_node()
+        .data_dir(tempdir)
+        .build()
         .unwrap();
     tokio::task::spawn(async move { node.run().await });
     async fn print_and_sync(mut client: Client) {


### PR DESCRIPTION
This is mostly an LSP related thing, where I think removing the verb for most methods makes them easier to find. Trying to push in anything breaking before [this is merged](https://github.com/bitcoindevkit/bdk-ffi/pull/591)

cc @nyonson 