### PR TITLE
build: new msrv job to isolate build tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        # Minumum Supported Rust Version (MSRV) is 1.63.0.
-        toolchain: [1.63.0, stable, beta, nightly]
-        include:
-          - toolchain: 1.63.0
-            msrv: true
+        toolchain: [stable, beta, nightly]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
@@ -25,25 +21,40 @@ jobs:
           rustup component add --toolchain ${{ matrix.toolchain }} rustfmt
           rustup component add --toolchain ${{ matrix.toolchain }} clippy
           rustup update ${{ matrix.toolchain }}
-      # - name: Pin dependencies
-      #   if: matrix.msrv
-      #   run: cargo update -p allocator-api2 --precise "0.2.9" --verbose
       - name: Lint all targets
-        if: ${{ !matrix.msrv }}
         run: cargo clippy --all-targets
       - name: Format
-        if: ${{ !matrix.msrv }}
         run: cargo fmt -- --check
       - name: Build with defeault features
         run: cargo build --verbose
       - name: Check release build on Rust ${{ matrix.toolchain }}
         run: cargo check --release --verbose --color always
       - name: Unit test
-        if: ${{ !matrix.msrv }}
         run: cargo test --verbose --lib
       - name: Doc test
-        if: ${{ !matrix.msrv }}
         run: cargo test --verbose --doc
+  # Check that library code can be compiled with MSRV (1.63.0).
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # Modify build tools just for MSRV testing. This avoids us having
+      # to bump our MSRV just for tooling. Tooling doesn't effect consumers so not a risk.
+      - name: Prepare environment for MSRV toolchain
+        run: |
+          # Remove resolver = "3" line for MSRV compatibility. We use V3 to
+          # generate an MSRV-compliant lockfile, but this isn't necessary to
+          # check if library code is MSRV compliant. Any resolver can go
+          # and grab the versions specified in the committed lockfile.
+          #
+          # The V3 resolver is standard in rust 1.85.
+          sed -i '/resolver = "3"/d' Cargo.toml
+      - name: Install MSRV toolchain
+        run: |
+          rustup toolchain install 1.63.0
+          rustup default 1.63.0
+      - name: Build with MSRV compiler
+        run: cargo build --verbose
   signet:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ repository = "https://github.com/rustaceanrob/kyoto"
 readme = "README.md"
 keywords = ["bitcoin", "cryptography", "network", "peer-to-peer"]
 categories = ["cryptography::cryptocurrencies"]
-resolver = "2"
+# MSRV-aware resolver which is the default in edition2024.
+resolver = "3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The msrv job checks just that the library code can be built with the MSRV's compiler, and that is it. All other build tooling functionallity doesn't need to be gated on the MSRV since it doesn't effect consumers. We specifically would rather use cargo's V3 resolver by default to generate our lockfiles.