### PR TITLE
build: run basic feature matrix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     strategy:
+      # Don't cancel other matrix jobs if one fails
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [stable, beta, nightly]
@@ -25,15 +27,18 @@ jobs:
         run: cargo clippy --all-targets
       - name: Format
         run: cargo fmt -- --check
-      - name: Build with defeault features
-        run: cargo build --verbose
-      - name: Check release build on Rust ${{ matrix.toolchain }}
-        run: cargo check --release --verbose --color always
+        # Check default features, all features, no features, some features.
+      - name: Build
+        run: |
+          cargo build --verbose
+          cargo build --verbose --all-features
+          cargo build --verbose --no-default-features
+          cargo build --verbose --no-default-features --features database,filter-control 
       - name: Unit test
         run: cargo test --verbose --lib
       - name: Doc test
         run: cargo test --verbose --doc
-  # Check that library code can be compiled with MSRV (1.63.0).
+  # Check that library code can be compiled with the MSRV (1.63.0) compiler.
   msrv:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 
 [features]
 default = ["database"]
-database = ["rusqlite"]
+database = ["dep:rusqlite"]
 filter-control = []
 
 [dev-dependencies]


### PR DESCRIPTION
First patch focuses on running *some* feature flag combinations, second patch fixes the tor dep so we can also run *all* feature flags.

Extending the "build" step to run all feature flags, as well as the existing default. Could possible add more flag combos in the future if things get complicated, but this should cover most cases for now. This helps ensure that the different flag combos exposed by the library actually build for consumers. If the feature flag matrix begins to get more complex, we could look into a more specific tool like cargo-hack, but for now simplicity is fine.

Switched to the optional dependency syntax which ensures that the (unused in our case) implicit features of the optional dependencies are not created. This cleans up the library interface for consumers, only our explicit flags are exposed.

Dropping the "check" CI step since build covers all of it. If build gets really slow in the future, we can add check back as a form of "fast failure", but as it is today this is just duplicating work and slowing CI down.

Requires bumping the tor dependencies due to a break in the pulled in time dependency. This is a conservative upgrade so we don't run into issues with the sqlite dependency, however the MSRV with the tor feature is still above the projects, 1.70.0.