### PR TITLE
build(dep): upgrade bip324 to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,9 +308,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip324"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b443a76f86143c093b211628be683ee592a097d316db6b90f723ed816bde1a49"
+checksum = "53157fcb2d6ec2851c7602d0690536d0b79209e393972cb2b36bd5d72dbd1879"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.15.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,7 @@ rust-version = "1.63.0"
 bitcoin = { version = "0.32.5", default-features = false, features = [
     "rand-std",
 ] }
-bip324 = { version = "0.6.0", default-features = false, features = [
-    "std",
-    "alloc",
+bip324 = { version = "0.7.0", default-features = false, features = [
     "tokio",
 ] }
 tokio = { version = "1.37", default-features = false, features = [


### PR DESCRIPTION
Dropping redundant features, tokio enables everything we need.