### PR TITLE
build(dep): loosen tokio requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bip324 = { version = "0.6.0", default-features = false, features = [
     "alloc",
     "tokio",
 ] }
-tokio = { version = "1.37", default-features = false, features = [
+tokio = { version = "1", default-features = false, features = [
     "rt-multi-thread",
     "sync",
     "time",


### PR DESCRIPTION
Since this is a library, let the consumer dictate the version of tokio which works for them. The library should operate against the v1 tokio interface to be as accommodating as possible.