### PR TITLE
Introduce `Info` and separate info/debug strings

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -45,8 +45,8 @@ async fn main() {
         .anchor_checkpoint(checkpoint)
         // The number of connections we would like to maintain
         .required_peers(1)
-        // Omit informational messages
-        .log_level(LogLevel::Warning)
+        // Omit debug messages
+        .log_level(LogLevel::Info)
         // Create the node and client
         .build()
         .unwrap();
@@ -55,17 +55,23 @@ async fn main() {
 
     let Client {
         requester,
-        mut log_rx,
-        warn_rx: _,
+        log_rx: _,
+        mut info_rx,
+        mut warn_rx,
         mut event_rx,
     } = client;
 
     // Continually listen for events until the node is synced to its peers.
     loop {
         tokio::select! {
-            log = log_rx.recv() => {
-                if let Some(log) = log {
-                    tracing::info!("{log}");
+            info = info_rx.recv() => {
+                if let Some(info) = info {
+                    tracing::info!("{info}");
+                }
+            }
+            warn = warn_rx.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}");
                 }
             }
             event = event_rx.recv() => {

--- a/example/rescan.rs
+++ b/example/rescan.rs
@@ -45,6 +45,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        mut info_rx,
         mut warn_rx,
         mut event_rx,
     } = client;
@@ -61,6 +62,11 @@ async fn main() {
             log = log_rx.recv() => {
                 if let Some(log) = log {
                     tracing::info!("{log}");
+                }
+            }
+            info = info_rx.recv() => {
+                if let Some(info) = info {
+                    tracing::info!("{info}");
                 }
             }
             warn = warn_rx.recv() => {

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -1,7 +1,7 @@
 //! Usual sync on Signet.
 
 use kyoto::{builder::NodeBuilder, chain::checkpoints::HeaderCheckpoint};
-use kyoto::{AddrV2, Address, Client, Event, Log, Network, ServiceFlags, TrustedPeer};
+use kyoto::{AddrV2, Address, Client, Event, Info, Network, ServiceFlags, TrustedPeer};
 use std::collections::HashSet;
 use std::{
     net::{IpAddr, Ipv4Addr},
@@ -57,6 +57,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        mut info_rx,
         mut warn_rx,
         mut event_rx,
     } = client;
@@ -84,14 +85,18 @@ async fn main() {
                     }
                 }
             }
-            log = log_rx.recv() => {
-                if let Some(log) = log {
-                    match log {
-                        Log::Debug(d)=> tracing::info!("{d}"),
-                        Log::StateChange(node_state) => tracing::info!("{node_state}"),
-                        Log::ConnectionsMet => tracing::info!("All required connections met"),
+            info = info_rx.recv() => {
+                if let Some(info) = info {
+                    match info {
+                        Info::StateChange(node_state) => tracing::info!("{node_state}"),
+                        Info::ConnectionsMet => tracing::info!("All required connections met"),
                         _ => (),
                     }
+                }
+            }
+            log = log_rx.recv() => {
+                if let Some(log) = log {
+                    tracing::info!("{log}");
                 }
             }
             warn = warn_rx.recv() => {

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -1,7 +1,7 @@
 //! Usual sync on Testnet.
 
 use kyoto::{builder::NodeBuilder, chain::checkpoints::HeaderCheckpoint};
-use kyoto::{Address, Client, Event, Log, Network, PeerStoreSizeConfig, TrustedPeer};
+use kyoto::{Address, Client, Event, Info, Network, PeerStoreSizeConfig, TrustedPeer};
 use std::collections::HashSet;
 use std::{net::Ipv4Addr, str::FromStr};
 
@@ -52,6 +52,7 @@ async fn main() {
     let Client {
         requester,
         mut log_rx,
+        mut info_rx,
         mut warn_rx,
         mut event_rx,
     } = client;
@@ -76,14 +77,18 @@ async fn main() {
                     }
                 }
             }
-            log = log_rx.recv() => {
-                if let Some(log) = log {
-                    match log {
-                        Log::Debug(d)=> tracing::info!("{d}"),
-                        Log::StateChange(node_state) => tracing::info!("{node_state}"),
-                        Log::ConnectionsMet => tracing::info!("All required connections met"),
+            info = info_rx.recv() => {
+                if let Some(info) = info {
+                    match info {
+                        Info::StateChange(node_state) => tracing::info!("{node_state}"),
+                        Info::ConnectionsMet => tracing::info!("All required connections met"),
                         _ => (),
                     }
+                }
+            }
+            log = log_rx.recv() => {
+                if let Some(log) = log {
+                    tracing::info!("{log}");
                 }
             }
             warn = warn_rx.recv() => {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -688,7 +688,7 @@ mod tests {
         filters::cfheader_chain::AppendAttempt,
         {
             dialog::Dialog,
-            messages::{Event, Log, Warning},
+            messages::{Event, Info, Warning},
         },
     };
 
@@ -699,7 +699,8 @@ mod tests {
         height_monitor: Arc<Mutex<HeightMonitor>>,
         peers: usize,
     ) -> Chain<()> {
-        let (log_tx, _) = tokio::sync::mpsc::channel::<Log>(1);
+        let (log_tx, _) = tokio::sync::mpsc::channel::<String>(1);
+        let (info_tx, _) = tokio::sync::mpsc::channel::<Info>(1);
         let (warn_tx, _) = tokio::sync::mpsc::unbounded_channel::<Warning>();
         let (event_tx, _) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let mut checkpoints = HeaderCheckpoints::new(&bitcoin::Network::Regtest);
@@ -712,6 +713,7 @@ mod tests {
             Arc::new(Dialog::new(
                 crate::LogLevel::Debug,
                 log_tx,
+                info_tx,
                 warn_tx,
                 event_tx,
             )),

--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, ops::Range, time::Duration};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 
-use crate::{Event, Log, TrustedPeer, TxBroadcast, Warning};
+use crate::{Event, Info, TrustedPeer, TxBroadcast, Warning};
 
 #[cfg(feature = "filter-control")]
 use super::{error::FetchBlockError, messages::BlockRequest, BlockReceiver, IndexedBlock};
@@ -22,8 +22,10 @@ use super::{
 pub struct Client {
     /// Send events to a node, such as broadcasting a transaction.
     pub requester: Requester,
-    /// Receive log messages from a node.
-    pub log_rx: mpsc::Receiver<Log>,
+    /// Receive log/debug messages from a node.
+    pub log_rx: mpsc::Receiver<String>,
+    /// Receive informational messages from the node.
+    pub info_rx: mpsc::Receiver<Info>,
     /// Receive warning messages from a node.
     pub warn_rx: mpsc::UnboundedReceiver<Warning>,
     /// Receive [`Event`] from a node to act on.
@@ -32,7 +34,8 @@ pub struct Client {
 
 impl Client {
     pub(crate) fn new(
-        log_rx: mpsc::Receiver<Log>,
+        log_rx: mpsc::Receiver<String>,
+        info_rx: mpsc::Receiver<Info>,
         warn_rx: mpsc::UnboundedReceiver<Warning>,
         event_rx: mpsc::UnboundedReceiver<Event>,
         ntx: Sender<ClientMessage>,
@@ -40,6 +43,7 @@ impl Client {
         Self {
             requester: Requester::new(ntx),
             log_rx,
+            info_rx,
             warn_rx,
             event_rx,
         }
@@ -354,25 +358,23 @@ mod tests {
     #[tokio::test]
     async fn test_client_works() {
         let transaction: Transaction = deserialize(&hex::decode("0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000").unwrap()).unwrap();
-        let (log_tx, log_rx) = tokio::sync::mpsc::channel::<Log>(1);
+        let (log_tx, log_rx) = tokio::sync::mpsc::channel::<String>(1);
+        let (_, info_rx) = tokio::sync::mpsc::channel::<Info>(1);
         let (_, warn_rx) = tokio::sync::mpsc::unbounded_channel::<Warning>();
         let (_, event_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
         let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
         let Client {
             requester,
             mut log_rx,
+            info_rx: _,
             warn_rx: _,
             event_rx: _,
-        } = Client::new(log_rx, warn_rx, event_rx, ctx);
-        let send_res = log_tx.send(Log::Debug("An important message".into())).await;
+        } = Client::new(log_rx, info_rx, warn_rx, event_rx, ctx);
+        let send_res = log_tx.send("An important message".into()).await;
         assert!(send_res.is_ok());
         let message = log_rx.recv().await;
         assert!(message.is_some());
-        tokio::task::spawn(async move {
-            log_tx
-                .send(Log::Debug("Another important message".into()))
-                .await
-        });
+        tokio::task::spawn(async move { log_tx.send("Another important message".into()).await });
         assert!(send_res.is_ok());
         let message = log_rx.recv().await;
         assert!(message.is_some());

--- a/src/dialog.rs
+++ b/src/dialog.rs
@@ -1,12 +1,13 @@
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 
-use super::messages::{Event, Log, Progress, Warning};
+use super::messages::{Event, Info, Progress, Warning};
 use crate::LogLevel;
 
 #[derive(Debug, Clone)]
 pub(crate) struct Dialog {
     pub(crate) log_level: LogLevel,
-    log_tx: Sender<Log>,
+    log_tx: Sender<String>,
+    info_tx: Sender<Info>,
     warn_tx: UnboundedSender<Warning>,
     event_tx: UnboundedSender<Event>,
 }
@@ -14,20 +15,22 @@ pub(crate) struct Dialog {
 impl Dialog {
     pub(crate) fn new(
         log_level: LogLevel,
-        log_tx: Sender<Log>,
+        log_tx: Sender<String>,
+        info_tx: Sender<Info>,
         warn_tx: UnboundedSender<Warning>,
         event_tx: UnboundedSender<Event>,
     ) -> Self {
         Self {
             log_level,
             log_tx,
+            info_tx,
             warn_tx,
             event_tx,
         }
     }
 
     pub(crate) async fn send_dialog(&self, dialog: impl Into<String>) {
-        let _ = self.log_tx.send(Log::Debug(dialog.into())).await;
+        let _ = self.log_tx.send(dialog.into()).await;
     }
 
     pub(crate) async fn chain_update(
@@ -37,20 +40,22 @@ impl Dialog {
         num_filters: u32,
         best_height: u32,
     ) {
-        let _ = self
-            .log_tx
-            .send(Log::Progress(Progress::new(
-                num_cf_headers,
-                num_filters,
-                best_height,
-            )))
-            .await;
+        if matches!(self.log_level, LogLevel::Debug | LogLevel::Info) {
+            let _ = self
+                .info_tx
+                .send(Info::Progress(Progress::new(
+                    num_cf_headers,
+                    num_filters,
+                    best_height,
+                )))
+                .await;
+        }
         if matches!(self.log_level, LogLevel::Debug) {
             let message = format!(
                 "Headers ({}/{}) Compact Filter Headers ({}/{}) Filters ({}/{})",
                 num_headers, best_height, num_cf_headers, best_height, num_filters, best_height
             );
-            let _ = self.log_tx.send(Log::Debug(message)).await;
+            let _ = self.log_tx.send(message).await;
         }
     }
 
@@ -58,8 +63,8 @@ impl Dialog {
         let _ = self.warn_tx.send(warning);
     }
 
-    pub(crate) async fn send_info(&self, info: Log) {
-        let _ = self.log_tx.send(info).await;
+    pub(crate) async fn send_info(&self, info: Info) {
+        let _ = self.info_tx.send(info).await;
     }
 
     pub(crate) fn send_event(&self, message: Event) {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -15,9 +15,7 @@ use super::error::{FetchBlockError, FetchHeaderError};
 
 /// Informational messages emitted by a node
 #[derive(Debug, Clone)]
-pub enum Log {
-    /// Human readable dialog of what the node is currently doing.
-    Debug(String),
+pub enum Info {
     /// The current state of the node in the syncing process.
     StateChange(NodeState),
     /// The node is connected to all required peers.
@@ -30,14 +28,13 @@ pub enum Log {
     TxSent(Txid),
 }
 
-impl core::fmt::Display for Log {
+impl core::fmt::Display for Info {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            Log::Debug(d) => write!(f, "{}", d),
-            Log::StateChange(s) => write!(f, "{}", s),
-            Log::TxSent(txid) => write!(f, "Transaction sent: {}", txid),
-            Log::ConnectionsMet => write!(f, "Required connections met"),
-            Log::Progress(p) => {
+            Info::StateChange(s) => write!(f, "{}", s),
+            Info::TxSent(txid) => write!(f, "Transaction sent: {}", txid),
+            Info::ConnectionsMet => write!(f, "Required connections met"),
+            Info::Progress(p) => {
                 let progress_percent = p.percentage_complete();
                 write!(f, "Percent complete: {}", progress_percent)
             }


### PR DESCRIPTION
#### Description

While it might be painful to have 4 different ways to handle messages, I think this design is worth the performance improvements if one would like to completely remove string allocations by omitting the debug messages. Informational messages can be useful but are far less chatty, and may potentially be expanded into the future (like positive matches for filters).

For a desktop application I don't see much harm in using the debug strings and writing to a log, but mobile users can't use the strings for much at all so they should have a way to omit them, but still get updates on the changes in state and such. 

#### Implementation
- Introduces a `info!` macro similar to `log!`, so informational messages aren't allocated with `LogLevel::Warning` set. 
- Adds a new receiver type and changes the `Log` enum to `Info`. The debug messages are emitted as strings and `Info` is an enum with the rest of the events