### PR TITLE
Use unbounded channels to avoid dropped requests

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -96,6 +96,6 @@ async fn main() {
             }
         }
     }
-    let _ = requester.shutdown().await;
+    let _ = requester.shutdown();
     tracing::info!("Shutting down");
 }

--- a/example/rescan.rs
+++ b/example/rescan.rs
@@ -82,9 +82,9 @@ async fn main() {
             .unwrap()
             .require_network(NETWORK)
             .unwrap();
-    requester.add_script(new_script).await.unwrap();
+    requester.add_script(new_script).unwrap();
     // // Tell the node to look for these new scripts
-    requester.rescan().await.unwrap();
+    requester.rescan().unwrap();
     tracing::info!("Starting rescan");
     loop {
         tokio::select! {
@@ -107,6 +107,6 @@ async fn main() {
             }
         }
     }
-    let _ = requester.shutdown().await;
+    let _ = requester.shutdown();
     tracing::info!("Shutting down");
 }

--- a/example/signet.rs
+++ b/example/signet.rs
@@ -106,6 +106,6 @@ async fn main() {
             }
         }
     }
-    let _ = requester.shutdown().await;
+    let _ = requester.shutdown();
     tracing::info!("Shutting down");
 }

--- a/example/testnet4.rs
+++ b/example/testnet4.rs
@@ -98,6 +98,6 @@ async fn main() {
             }
         }
     }
-    let _ = requester.shutdown().await;
+    let _ = requester.shutdown();
     tracing::info!("Shutting down");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!             }
 //!         }
 //!     }
-//!     requester.shutdown().await;
+//!     requester.shutdown();
 //! }
 //! ```
 //!

--- a/src/node.rs
+++ b/src/node.rs
@@ -9,7 +9,10 @@ use bitcoin::{
     },
     Block, BlockHash, Network, ScriptBuf,
 };
-use tokio::sync::{mpsc::Receiver, Mutex, RwLock};
+use tokio::sync::{
+    mpsc::{Receiver, UnboundedReceiver},
+    Mutex, RwLock,
+};
 use tokio::{
     select,
     sync::mpsc::{self},
@@ -55,7 +58,7 @@ pub struct Node<H: HeaderStore, P: PeerStore> {
     tx_broadcaster: Arc<Mutex<Broadcaster>>,
     required_peers: PeerRequirement,
     dialog: Arc<Dialog>,
-    client_recv: Arc<Mutex<Receiver<ClientMessage>>>,
+    client_recv: Arc<Mutex<UnboundedReceiver<ClientMessage>>>,
     peer_recv: Arc<Mutex<Receiver<PeerThreadMessage>>>,
     filter_sync_policy: Arc<RwLock<FilterSyncPolicy>>,
 }
@@ -87,7 +90,7 @@ impl<H: HeaderStore, P: PeerStore> Node<H, P> {
         let (info_tx, info_rx) = mpsc::channel::<Info>(32);
         let (warn_tx, warn_rx) = mpsc::unbounded_channel::<Warning>();
         let (event_tx, event_rx) = mpsc::unbounded_channel::<Event>();
-        let (ctx, crx) = mpsc::channel::<ClientMessage>(5);
+        let (ctx, crx) = mpsc::unbounded_channel::<ClientMessage>();
         let client = Client::new(log_rx, info_rx, warn_rx, event_rx, ctx);
         // A structured way to talk to the client
         let dialog = Arc::new(Dialog::new(log_level, log_tx, info_tx, warn_tx, event_tx));

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -171,13 +171,13 @@ async fn live_reorg() {
             }
             kyoto::messages::Event::Synced(update) => {
                 assert_eq!(update.tip().hash, best);
-                requester.shutdown().await.unwrap();
+                requester.shutdown().unwrap();
                 break;
             }
             _ => {}
         }
     }
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 
@@ -231,7 +231,7 @@ async fn live_reorg_additional_sync() {
     mine_blocks(rpc, &miner, 2, 1).await;
     let best = best_hash(rpc);
     sync_assert(&best, &mut channel).await;
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 
@@ -263,9 +263,9 @@ async fn various_client_methods() {
     let _ = requester.broadcast_min_feerate().await.unwrap();
     let _ = requester.get_header(3).await.unwrap();
     let script = rpc.new_address().unwrap();
-    requester.add_script(script).await.unwrap();
-    assert!(requester.is_running().await);
-    requester.shutdown().await.unwrap();
+    requester.add_script(script).unwrap();
+    assert!(requester.is_running());
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 
@@ -294,7 +294,7 @@ async fn stop_reorg_resync() {
     sync_assert(&best, &mut channel).await;
     let batch = requester.get_header_range(0..10).await.unwrap();
     assert!(!batch.is_empty());
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     // Reorganize the blocks
     let old_best = best;
     let old_height = num_blocks(rpc);
@@ -328,7 +328,7 @@ async fn stop_reorg_resync() {
             _ => {}
         }
     }
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     drop(handle);
     // Mine more blocks
     mine_blocks(rpc, &miner, 2, 1).await;
@@ -346,7 +346,7 @@ async fn stop_reorg_resync() {
     tokio::task::spawn(async move { print_logs(log_rx, warn_rx).await });
     // The node properly syncs after persisting a reorg
     sync_assert(&best, &mut channel).await;
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 
@@ -373,7 +373,7 @@ async fn stop_reorg_two_resync() {
     } = client;
     let handle = tokio::task::spawn(async move { print_logs(log_rx, warn_rx).await });
     sync_assert(&best, &mut channel).await;
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     // Reorganize the blocks
     let old_height = num_blocks(rpc);
     let old_best = best;
@@ -410,7 +410,7 @@ async fn stop_reorg_two_resync() {
         }
     }
     drop(handle);
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     // Mine more blocks
     mine_blocks(rpc, &miner, 2, 1).await;
     let best = best_hash(rpc);
@@ -427,7 +427,7 @@ async fn stop_reorg_two_resync() {
     tokio::task::spawn(async move { print_logs(log_rx, warn_rx).await });
     // The node properly syncs after persisting a reorg
     sync_assert(&best, &mut channel).await;
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 
@@ -454,7 +454,7 @@ async fn stop_reorg_start_on_orphan() {
     let handle = tokio::task::spawn(async move { print_logs(log_rx, warn_rx).await });
     sync_assert(&best, &mut channel).await;
     drop(handle);
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     // Reorganize the blocks
     let old_best = best;
     let old_height = num_blocks(rpc);
@@ -494,7 +494,7 @@ async fn stop_reorg_start_on_orphan() {
         }
     }
     drop(handle);
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     // Don't do anything, but reload the node from the checkpoint
     let cp = best_hash(rpc);
     let old_height = num_blocks(rpc);
@@ -518,7 +518,7 @@ async fn stop_reorg_start_on_orphan() {
     // The node properly syncs after persisting a reorg
     sync_assert(&best, &mut channel).await;
     drop(handle);
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     // Mine more blocks and reload from the checkpoint
     let cp = best_hash(rpc);
     let old_height = num_blocks(rpc);
@@ -542,7 +542,7 @@ async fn stop_reorg_start_on_orphan() {
     tokio::task::spawn(async move { print_logs(log_rx, warn_rx).await });
     // The node properly syncs after persisting a reorg
     sync_assert(&best, &mut channel).await;
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 
@@ -583,7 +583,7 @@ async fn halting_download_works() {
             if let kyoto::NodeState::FilterHeadersSynced = node_state {
                 println!("Sleeping for one second...");
                 tokio::time::sleep(Duration::from_secs(1)).await;
-                requester.continue_download().await.unwrap();
+                requester.continue_download().unwrap();
                 break;
             }
         }
@@ -596,7 +596,7 @@ async fn halting_download_works() {
             break;
         }
     }
-    requester.shutdown().await.unwrap();
+    requester.shutdown().unwrap();
     rpc.stop().unwrap();
 }
 


### PR DESCRIPTION
The `UnboundedSender` offers two advantages over bounding the number of requests a client can make. First it drops the need to maintain an `async` and sync version of the client methods - `UnboundedSender::send` is synchronous. This is actually very convient for `ldk-node`, where the client will have to implement a synchronous trait.

Secondly there are some methods that are critical to succeed if the node is running. Adding a script must always work if the node is still online. Because it is unacceptable to miss some messages, there is basically two approaches: cache the failures and try again later, or use an unbounded channel. Since caching the failures will result in the exact same overhead as stored messages in a channel when the node is not ready to accept them yet, the unbounded channel is much easier to implement and reason about.