### PR TITLE
build: add minimal dependency versions test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,12 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - run: just test integration
+  min-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: extractions/setup-just@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+      - run: just test min-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bitcoin = { version = "0.32.5", default-features = false, features = [
 bip324 = { version = "0.7.0", default-features = false, features = [
     "tokio",
 ] }
-tokio = { version = "1", default-features = false, features = [
+tokio = { version = "1.19", default-features = false, features = [
     "rt-multi-thread",
     "sync",
     "time",
@@ -43,7 +43,7 @@ hex = { version = "0.4.0" }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tempfile = "3"
-tokio = { version = "1.37", default-features = false, features = [
+tokio = { version = "1.19", default-features = false, features = [
     "full",
 ] }
 

--- a/justfile
+++ b/justfile
@@ -11,7 +11,7 @@ check:
   cargo clippy --all-targets -- -D warnings
   cargo check --all-features
 
-# Run a test suite: unit, integration, features, msrv, or sync.
+# Run a test suite: unit, integration, features, msrv, min-versions, or sync.
 test suite="unit":
   just _test-{{suite}}
 
@@ -36,6 +36,11 @@ _test-features:
   cargo test --lib --no-default-features
   cargo test --lib --no-default-features --features rusqlite,filter-control 
 
+# Test that minimum versions of dependency contraints are still valid.
+_test-min-versions:
+  just _delete-lockfile
+  cargo +nightly check --all-features -Z direct-minimal-versions
+
 # Check code with MSRV compiler.
 _test-msrv:
   # Handles creating sandboxed environments to ensure no newer binaries sneak in.
@@ -54,7 +59,7 @@ _delete-data:
   rm -rf light_client_data
 
 _delete-lockfile:
-  rm Cargo.lock
+  rm -f Cargo.lock
 
 _delete-branches:
   git branch --merged | grep -v \* | xargs git branch -d


### PR DESCRIPTION
Add a test that verifies the crate compiles with minimal dependency versions using cargo's -Z direct-minimal-versions flag. This keeps us honest from accidentally depending on features in a new version of a dependency without updating the manifest.

The new test revealed a dependency on tokio `^1.19` since we use the `is_finished` function.

The `-f` setting is now used in the delete lockfile recipe so that there is no error when no file, making it easier to compose.