### PR TITLE
Avoid requesting duplicate blocks

### DIFF
--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -537,6 +537,9 @@ impl<H: HeaderStore> Chain<H> {
 
         #[cfg(not(feature = "filter-control"))]
         if !self.block_queue.contains(&filter_message.block_hash)
+            && !self
+                .header_chain
+                .is_filter_checked(&filter_message.block_hash)
             && filter
                 .contains_any(self.scripts.iter())
                 .map_err(CFilterSyncError::Filter)?

--- a/src/chain/graph.rs
+++ b/src/chain/graph.rs
@@ -453,6 +453,13 @@ impl BlockTree {
         }
     }
 
+    pub(crate) fn is_filter_checked(&self, hash: &BlockHash) -> bool {
+        if let Some(node) = self.headers.get(hash) {
+            return node.filter_checked;
+        }
+        false
+    }
+
     pub(crate) fn reset_all_filters(&mut self) {
         let mut curr = self.tip_hash();
         while let Some(node) = self.headers.get_mut(&curr) {


### PR DESCRIPTION
The node may request filters of multiple peers to speed up the filter syncing process. If a filter is checked and the desired block is fetched quickly, the current code will request that block again if the filter is seen again (from a super laggy peer). Instead, only add blocks to the request queue for the filters we haven't already checked