### PR TITLE
Fix the `filter-control` API

### DIFF
--- a/example/managed.rs
+++ b/example/managed.rs
@@ -77,7 +77,7 @@ async fn main() {
             event = event_rx.recv() => {
                 if let Some(event) = event {
                     match event {
-                        Event::IndexedFilter(mut filter) => {
+                        Event::IndexedFilter(filter) => {
                             let height = filter.height();
                             tracing::info!("Checking filter: {height}");
                             if filter.contains_any(addresses.iter()) {

--- a/src/chain/chain.rs
+++ b/src/chain/chain.rs
@@ -508,8 +508,7 @@ impl<H: HeaderStore> Chain<H> {
         if self.is_filters_synced() {
             return Ok(None);
         }
-        #[allow(unused_mut)]
-        let mut filter = Filter::new(filter_message.filter, filter_message.block_hash);
+        let filter = Filter::new(filter_message.filter, filter_message.block_hash);
         let expected_filter_hash = self
             .header_chain
             .filter_commitment(filter_message.block_hash);
@@ -526,6 +525,9 @@ impl<H: HeaderStore> Chain<H> {
         }
 
         #[cfg(feature = "filter-control")]
+        if !self
+            .header_chain
+            .is_filter_checked(&filter_message.block_hash)
         {
             let height = self
                 .height_of_hash(filter_message.block_hash)

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -144,12 +144,16 @@ impl Filter {
     }
 
     pub fn contains_any<'a>(
-        &'a mut self,
+        &'a self,
         scripts: impl Iterator<Item = &'a ScriptBuf>,
     ) -> Result<bool, FilterError> {
         self.block_filter
             .match_any(&self.block_hash, scripts.map(|script| script.to_bytes()))
             .map_err(|_| FilterError::IORead)
+    }
+
+    pub fn contents(self) -> Vec<u8> {
+        self.block_filter.content
     }
 }
 


### PR DESCRIPTION
- Changes in `chain` were missed when considering duplicate filters. Removing duplicate emissions is desirable for the managed filter workflow as well as the usual flow. #342 should've caught this.

- `Filter::match_any` doesn't need to be mutable.

- It should also be possible to consume a filter and get raw bytes, perhaps to save it to disk. When loading from disk, the `BlockFilter` struct from `bitcoin` is exposed to check it for matches. Leaving `chain::Filter` private for now in case the API needs discussion.

- Implemented `Ord` on `IndexedFilter` because they can be ordered by height

- Also removed a struct I thought might be useful at the beginning of the project but hasn't proved interesting