### PR TITLE
Release `0.10.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ Notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.0
+
+## Added
+
+- Template issue for bugs, enhancement requests, releases
+- Mainnet, signet, testnet4 checkpoints
+- Testnet4 DNS seeds
+- Socks5 proxy connections supported
+- `justfile` improvements
+
+## Changed
+
+- Removed the crate lockfile
+- Removed the `core` module
+- Removed the `filter` module
+- Renamed `DisconnectedHeader` to `IndexedHeader`
+- `database` feature is now `rusqlite`
+- Remove `arti` and Tor feature in favor of a Socks5 proxy
+- Folder for data storage is now `light_client_data`
+- SQL header schema has been changed to store `BLOB` of consensus encoded header bytes
+- New log level introduced and `Log` has been renamed to `Info`
+- Debug strings sent on a separate channel
+- Sending messages to the node is synchronous
+- Checking `IndexedFilter` for matches is immutable
+
+## Fixes
+- Introduce `BlockTree` to manage chain data
+    - Constant time data access when indexed by height or hash
+    - Consolidated block headers, filter headers/hashes, filter checks into a single struct
+    - Management of candidate forks
+    - Constant time fork comparison
+- CI refactors and improvements
+
 ## 0.9.0
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kyoto-cbf"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Rob <rustaceanrob@protonmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -19,7 +19,7 @@ use crate::{
 use crate::{FilterSyncPolicy, LogLevel, PeerStoreSizeConfig, TrustedPeer};
 
 #[cfg(feature = "rusqlite")]
-/// The default node returned from the [`NodeBuilder`](crate::core).
+/// The default node returned from the [`NodeBuilder`].
 pub type NodeDefault = Node<SqliteHeaderDb, SqlitePeerDb>;
 
 const MIN_PEERS: u8 = 1;

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -31,7 +31,7 @@ pub(crate) mod socks;
 pub(crate) mod traits;
 
 pub const PROTOCOL_VERSION: u32 = 70016;
-pub const KYOTO_VERSION: &str = "0.8.0";
+pub const KYOTO_VERSION: &str = "0.10.0";
 pub const RUST_BITCOIN_VERSION: &str = "0.32.4";
 
 const THIRTY_MINS: u64 = 60 * 30;


### PR DESCRIPTION
Building on #343 

Updated the crate version, changelog, and user agent. `dry-run` passes and docs look good.

Closes #345 